### PR TITLE
ISSUE-12 Duplicate definition of ID: lux in reprSciUnits.owl

### DIFF
--- a/2.4/reprSciUnits.owl
+++ b/2.4/reprSciUnits.owl
@@ -635,6 +635,7 @@
   <units:UnitDefinedByProduct rdf:ID="lux">
     <mrela:hasOperand rdf:resource="#perMeterSquared"/>
     <mrela:hasOperand rdf:resource="#candela"/>
+    <mrela:hasOperand rdf:resource="#lumen"/>
     <screla:hasSymbol rdf:datatype="&xsd;string">Lx</screla:hasSymbol>
   </units:UnitDefinedByProduct>
 
@@ -678,11 +679,6 @@
   <units:UnitDefinedByProduct rdf:ID="meterPerKelvin">
     <mrela:hasOperand rdf:resource="#perKelvin"/>
     <mrela:hasOperand rdf:resource="#meter"/>
-  </units:UnitDefinedByProduct>
-
-  <units:UnitDefinedByProduct rdf:ID="lux">
-    <mrela:hasOperand rdf:resource="#perMeterSquared"/>
-    <mrela:hasOperand rdf:resource="#lumen"/>
   </units:UnitDefinedByProduct>
 
   <units:UnitDefinedByProduct rdf:ID="kelvinPerMeter">


### PR DESCRIPTION
This issue addresses #12 
I've checked out the [SI Photometry Units](https://en.wikipedia.org/wiki/Lux#SI_photometry_units) and I think we need to discuss the accuracy of the definition within SWEET.