### PR TITLE
add tools/ subdirectory

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -3,8 +3,8 @@ manipulation of the ontology files.
 
 The `*.sc` files are Scala scripts to be run via the 
 [Ammonite](http://ammonite.io/#ScalaScripts) tool, which in 
-particular greatly the use of Java libraries like Jena and OWL-API,
-two of the main libraries for ontology manipulation.
+particular, greatly facilitates the use of Java libraries like 
+Jena and OWL-API, two of the main libraries for ontology manipulation.
 
 As an example, [`ttl_prettify.sc`](ttl_prettify.sc) was the
 script used to resolve [#62](https://github.com/ESIPFed/sweet/issues/62).

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,11 @@
+This directory contains some utilities and scripts for 
+manipulation of the ontology files.
+
+The `*.sc` files are Scala scripts to be run via the 
+[Ammonite](http://ammonite.io/#ScalaScripts) tool, which in 
+particular greatly the use of Java libraries like Jena and OWL-API,
+two of the main libraries for ontology manipulation.
+
+As an example, [`ttl_prettify.sc`](ttl_prettify.sc) was the
+script used to resolve [#62](https://github.com/ESIPFed/sweet/issues/62).
+See file source for details.

--- a/tools/jena.sc
+++ b/tools/jena.sc
@@ -1,0 +1,29 @@
+/*
+  An ad hoc Jena-based utility.
+ */
+
+import $ivy.`org.apache.jena:jena:3.2.0`
+import $ivy.`org.apache.jena:jena-tdb:3.2.0`
+import org.apache.jena.ontology.{OntDocumentManager, OntModel, OntModelSpec}
+import org.apache.jena.rdf.model.ModelFactory
+import java.io.{File, FileInputStream}
+
+object jena {
+  def loadOntModel(file: File, iri: String): OntModel = {
+    val spec = new OntModelSpec(OntModelSpec.OWL_MEM)
+    spec.setDocumentManager(new OntDocumentManager)
+    val model: OntModel = ModelFactory.createOntologyModel(spec, null)
+    model.setDynamicImports(false)
+    model.getDocumentManager.setProcessImports(false)
+    val lang = if (file.getName.endsWith(".ttl")) "TTL" else "RDF/XML"
+    val is = new FileInputStream(file)
+    try model.read(is, iri, lang)
+    finally is.close()
+    model
+  }
+
+  def getNsPrefixMap(ont: OntModel): Map[String,String] = {
+    import collection.JavaConverters._
+    ont.getNsPrefixMap.asScala.toMap
+  }
+}

--- a/tools/owlApi.sc
+++ b/tools/owlApi.sc
@@ -1,0 +1,47 @@
+/*
+  An ad hoc OWL-API-based utility.
+ */
+
+import $ivy.`net.sourceforge.owlapi:owlapi-distribution:5.1.2`
+import org.semanticweb.owlapi.formats.TurtleDocumentFormat
+import org.semanticweb.owlapi.model._
+import org.semanticweb.owlapi.apibinding.OWLManager
+import org.semanticweb.owlapi.io.FileDocumentSource
+import java.io.File
+import java.nio.file.Files
+
+object owlApi {
+  private val manager: OWLOntologyManager = OWLManager.createOWLOntologyManager
+
+  def loadOntModel(file: File, iri: String): OWLOntology = {
+    manager.getIRIMappers.clear() // https://sourceforge.net/p/owlapi/mailman/message/23787202/
+    val configurator = new OntologyConfigurator()
+      .withUseNamespaceEntities(true)
+      .setLoadAnnotationAxioms(false)
+      .setStrict(false)
+      .setMissingImportHandlingStrategy(MissingImportHandlingStrategy.SILENT)
+      .setRetriesToAttempt(0)
+
+    val conf = configurator.buildLoaderConfiguration()
+    val docSource = new FileDocumentSource(file)
+    manager.loadOntologyFromOntologyDocument(docSource, conf)
+  }
+
+  def saveOntModel(base: String, model: OWLOntology, toFile: File,
+                   nsPrefixMap: Map[String,String] = Map.empty): Unit = {
+
+    val defaultPrefix = base + "/"
+
+    val turtleFormat = new TurtleDocumentFormat()
+    turtleFormat.setDefaultPrefix(defaultPrefix)
+
+    nsPrefixMap foreach { case (prefixName, prefix) ⇒
+      //if (prefix != defaultPrefix)
+      turtleFormat.setPrefix(prefixName, prefix)
+    }
+
+    val out = Files.newOutputStream(toFile.toPath)
+    try manager.saveOntology(model, turtleFormat, out)
+    finally out.close()
+  }
+}

--- a/tools/ttl_prettify.sc
+++ b/tools/ttl_prettify.sc
@@ -1,0 +1,63 @@
+#!/usr/bin/env amm
+//
+// This Ammonite script reads in SWEET turtle files and generates
+// them again "prettified," that is, with blank nodes using the
+// `[ ... ]` syntax as supported by OWL-API.
+// More in concrete, prettifying is simply loading and saving the
+// model in the file, while also retaining the original prefixes
+// (which are obtained using Jena).
+//
+// Use the 'convert' command to generate the result in a file
+// with suffix `.owlapi.ttl` (in the same directory), or the
+// 'replace' command to overwrite the input file.
+//
+// USAGE:
+//       ./ttl_prettify.sc convert files ...
+//       ./ttl_prettify.sc replace files ...
+//
+// Example: replace all ttl files in some directory:
+//       ./ttl_prettify.sc replace path/to/*.ttl
+//
+
+@main
+def convert(sweets: String*) = doIt(sweets, replace = false)
+
+@main
+def replace(sweets: String*) = doIt(sweets, replace = true)
+
+import java.io.File
+
+def doIt(sweets: Seq[String], replace: Boolean) = {
+  sweets foreach { sweet ⇒
+    val file = new File(sweet)
+    if (file.exists())
+      prettifyTurtle(file, replace)
+    else
+      println(s"$file: file not found")
+  }
+}
+
+import $ivy.`org.slf4j:slf4j-nop:1.7.25`
+import $file.jena, jena.jena
+import $file.owlApi, owlApi.owlApi
+
+def prettifyTurtle(inFile: File, replace: Boolean) {
+  val sweet = inFile.getName.replaceFirst("\\.ttl$", "")
+  val iri = s"http://sweetontology.net/$sweet"
+  val filename = s"$sweet.ttl"
+
+  // use Jena to get the prefixes:
+  val nsPrefixMap = jena.getNsPrefixMap(jena.loadOntModel(inFile, iri))
+
+  println(s"\nprettifying $sweet")
+  val outFile = if (replace) inFile
+  else new File(inFile.getParentFile, s"$filename.owlapi.ttl")
+
+  // use OWL-API to regenerate the turtle representation:
+  println(s"\t- loading $inFile")
+  val ont = owlApi.loadOntModel(inFile, iri)
+  println(s"\t- saving $outFile")
+  owlApi.saveOntModel(iri, ont, outFile, nsPrefixMap)
+
+  if (replace) println(s"\t- $inFile overwritten")
+}


### PR DESCRIPTION
@lewismc @dr-shorthair 
For your consideration, the general idea here is to have a place for misc utilities and scripts for ontology manipulation. Right now, this directory contains the supporting code for #62, but could be expanded as needed (for example, scripts for automatic registration at the COR, etc.). Also, it's still pretty flat but can of course later on be organized in subdirectories as deemed convenient.