### PR TITLE
fix spelling, update labels for namespaces ***PROBLEM***

### DIFF
--- a/src/humanAgriculture.ttl
+++ b/src/humanAgriculture.ttl
@@ -18,7 +18,7 @@
                                                          <http://sweetontology.net/matrCompound> ,
                                                          <http://sweetontology.net/relaChemical> ,
                                                          <http://sweetontology.net/relaSci> ;
-                                             rdfs:label "Human agrigculture-SWEET Ontology" ;
+                                             rdfs:label "Human agriculture-SWEET Ontology" ;
                                              owl:versionInfo "3.2.0" .
 
 #################################################################


### PR DESCRIPTION
@lewismc -- sorry about the confusion, somehow the new ISSUE-85 branch now has changes (see the rdfs:label properties at the top of the Human***.ttl files) that are not registering as changes against master. Looks to me like best would be to revert master to the 3.2.0 release (6396d18d78fb72265b413f91dbaccbfb7f90886b), and then (assuming the label updates suggested are acceptable) merge the ISSUE-85 branch to master.   I was following the contribute instructions, but apparently GitWindows does not do what I expected when I pushed the new branch. This last commit is a minor spelling fix in one of the labels. 