### PR TITLE
Changing alignment on res:Sample to sosa:Sample

### DIFF
--- a/alignments/sweet-ssn-mapping.ttl
+++ b/alignments/sweet-ssn-mapping.ttl
@@ -67,24 +67,47 @@
 .
 res:Observation
   rdfs:subClassOf sosa:Observation ;
+  rdfs:label "Observation"@en ;
+  skos:definition "Act of carrying out an (Observation) Procedure to estimate or calculate a value of a property of a FeatureOfInterest. Links to a Sensor to describe what made the Observation and how; links to an ObservableProperty to describe what the result is an estimate of, and to a FeatureOfInterest to detail what that property was associated with."@en ;
+  rdfs:comment "Act of carrying out an (Observation) Procedure to estimate or calculate a value of a property of a FeatureOfInterest. Links to a Sensor to describe what made the Observation and how; links to an ObservableProperty to describe what the result is an estimate of, and to a FeatureOfInterest to detail what that property was associated with."@en ;
+  rdfs:isDefinedBy sosa: ;
 .
 res:Result
   rdfs:subClassOf sosa:Result ;
+  rdfs:label "Result"@en ;
+  skos:definition "The Result of an Observation, Actuation, or act of Sampling. To store an observation's simple result value one can use the hasSimpleResult property."@en ;
+  rdfs:comment "The Result of an Observation, Actuation, or act of Sampling. To store an observation's simple result value one can use the hasSimpleResult property."@en ;
+  rdfs:isDefinedBy sosa: ;
 .
 res:Sample
-  rdfs:subClassOf sosa:Sampling ;
+  rdfs:label "Sample"@en ;
+  skos:definition "Feature which is intended to be representative of a FeatureOfInterest on which Observations may be made."@en ;
+  rdfs:comment "Feature which is intended to be representative of a FeatureOfInterest on which Observations may be made."@en ;
+  rdfs:comment "Physical samples are sometimes known as 'specimens'."@en ;
+  rdfs:comment "A Sample is the result from an act of Sampling."@en ;
+  rdfs:isDefinedBy sosa: ;
+  rdfs:subClassOf sosa:Sample ;
 .
 res:Variable
   rdfs:comment "Not quite sure about alignment to ssn:Property here" ;
   rdfs:subClassOf ssn:Property ;
+  rdfs:label "Variable"@en ;
 .
 prop:Property
   owl:equivalentClass ssn:Property ;
+  rdfs:isDefinedBy sosa: ;
+  rdfs:label "Property"@en ;
+  skos:definition "A quality of an entity. An aspect of an entity that is intrinsic to and cannot exist without the entity."@en ;
+  rdfs:comment "A quality of an entity. An aspect of an entity that is intrinsic to and cannot exist without the entity."@en ;
 .
 stat:Sampling
   rdfs:subClassOf sosa:Sampling ;
+  rdfs:label "Sampling"@en ;
+  skos:definition "An act of Sampling carries out a sampling Procedure to create or transform one or more samples."@en ;
+  rdfs:comment "An act of Sampling carries out a sampling Procedure to create or transform one or more samples."@en ;
 .
 stat:StatisticalSample
   rdfs:subClassOf sosa:Sample ;
+  rdfs:label "StatisticalSample"@en ;
   skos:note "Is the subclass relationship from StatisticalSample to humanResearchSample the right way round here? Or are they both subclasses of sosa:Sample? " ;
 .


### PR DESCRIPTION
Changed alignment of res:Sample from sosa:Sampling to sosa:Sample. Added some definitions rdfs:comment and skos:definition so that we can populate documentation.

Checked in Protege. Note, there is a pre-existing import problem with :
```
owl:imports <http://purl.org/vocommons/voaf> ;
```
I think the issue is with the purl.org redirect. 