### PR TITLE
fixed typo in phenAtmoWindMesoscale.ttl URI

### DIFF
--- a/sweetPrefixes.ttl
+++ b/sweetPrefixes.ttl
@@ -78,7 +78,7 @@ _:node1d2gh57gtx112400 a foaf:Person;
 ,[ sh:prefix "sophatmos" ; sh:namespace "http://sweetontology.net/phenAtmoSky/"]
 ,[ sh:prefix "sophatmot" ; sh:namespace "http://sweetontology.net/phenAtmoTransport/"]
 ,[ sh:prefix "sophatmow" ; sh:namespace "http://sweetontology.net/phenAtmoWind/"]
-,[ sh:prefix "sophatmowm" ; sh:namespace "http://sweetontology.net/phenAtmoWindMesostcale/"]
+,[ sh:prefix "sophatmowm" ; sh:namespace "http://sweetontology.net/phenAtmoWindMesoscale/"]
 ,[ sh:prefix "sophb" ; sh:namespace "http://sweetontology.net/phenBiol/"]
 ,[ sh:prefix "sophcr" ; sh:namespace "http://sweetontology.net/phenCryo/"]
 ,[ sh:prefix "sophcy" ; sh:namespace "http://sweetontology.net/phenCycle/"]


### PR DESCRIPTION
removed the 't' from the https://sweetontology.net/phenAtmoWindMesoscale.ttl URI in the SHACL file.  

also, go here 
http://prefix.cc/sophatmowm
and upvote the corrected URI