### PR TITLE
ISSUE-169 Address erroneous usage of punning - a name can only be use…d for one kind of property

### DIFF
--- a/src/propEnergyFlux.ttl
+++ b/src/propEnergyFlux.ttl
@@ -49,10 +49,6 @@ sorelsc:hasDefaultUnit rdf:type owl:ObjectProperty .
 sorelsc:hasSource rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 #################################################################
 #    Classes
 #################################################################

--- a/src/propQuantity.ttl
+++ b/src/propQuantity.ttl
@@ -27,10 +27,6 @@
 sorelsc:hasDefaultUnit rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 #################################################################
 #    Classes
 #################################################################

--- a/src/propSpaceDistance.ttl
+++ b/src/propSpaceDistance.ttl
@@ -43,10 +43,6 @@ sorel:hasProcess rdf:type owl:ObjectProperty .
 sorelsc:hasDefaultUnit rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 ###  http://sweetontology.net/relaSci/measureOf
 sorelsc:measureOf rdf:type owl:ObjectProperty .
 

--- a/src/propSpaceHeight.ttl
+++ b/src/propSpaceHeight.ttl
@@ -33,10 +33,6 @@
 sorel:hasRealm rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 ###  http://sweetontology.net/relaSci/rangeOf
 sorelsc:rangeOf rdf:type owl:ObjectProperty .
 

--- a/src/propTemperatureGradient.ttl
+++ b/src/propTemperatureGradient.ttl
@@ -46,10 +46,6 @@ sorelm:derivativeWithRespectTo rdf:type owl:ObjectProperty .
 sorelm:hasGradient rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 ###  http://sweetontology.net/relaSci/rangeOf
 sorelsc:rangeOf rdf:type owl:ObjectProperty .
 

--- a/src/propTimeFrequency.ttl
+++ b/src/propTimeFrequency.ttl
@@ -48,10 +48,6 @@ sorelm:hasOutput rdf:type owl:ObjectProperty .
 sorelsc:hasDefaultUnit rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 ###  http://sweetontology.net/relaSci/measureOf
 sorelsc:measureOf rdf:type owl:ObjectProperty .
 

--- a/src/realmOceanFeature.ttl
+++ b/src/realmOceanFeature.ttl
@@ -40,10 +40,6 @@
 sorelph:hasAstronomicalBody rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 #################################################################
 #    Classes
 #################################################################

--- a/src/realmRegion.ttl
+++ b/src/realmRegion.ttl
@@ -25,13 +25,6 @@
                                         rdfs:label "SWEET Ontology Realm Region" ;
                                         owl:versionInfo "3.3.0" .
 
-#################################################################
-#    Object Properties
-#################################################################
-
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
 
 #################################################################
 #    Data properties

--- a/src/reprSpaceCoordinate.ttl
+++ b/src/reprSpaceCoordinate.ttl
@@ -27,10 +27,6 @@
 sorelsp:orthogonalTo rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSpace/perpendicularTo
-sorelsp:perpendicularTo rdf:type owl:ObjectProperty .
-
-
 #################################################################
 #    Classes
 #################################################################

--- a/src/reprSpaceDirection.ttl
+++ b/src/reprSpaceDirection.ttl
@@ -27,10 +27,6 @@ sorelsp:oppositeTo rdf:type owl:AnnotationProperty .
 sorelsp:orthogonalTo rdf:type owl:AnnotationProperty .
 
 
-###  http://sweetontology.net/relaSpace/perpendicularTo
-sorelsp:perpendicularTo rdf:type owl:AnnotationProperty .
-
-
 #################################################################
 #    Classes
 #################################################################

--- a/src/reprTimeSeason.ttl
+++ b/src/reprTimeSeason.ttl
@@ -70,10 +70,6 @@ sorelm:hasMaximum rdf:type owl:ObjectProperty .
 sorelm:hasMinimum rdf:type owl:ObjectProperty .
 
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:ObjectProperty .
-
-
 #################################################################
 #    Classes
 #################################################################

--- a/src/stateTime.ttl
+++ b/src/stateTime.ttl
@@ -27,9 +27,6 @@
 #    Annotation properties
 #################################################################
 
-###  http://sweetontology.net/relaSci/hasUnit
-sorelsc:hasUnit rdf:type owl:AnnotationProperty .
-
 
 ###  http://sweetontology.net/relaTime/olderThan
 sorelt:olderThan rdf:type owl:AnnotationProperty .


### PR DESCRIPTION
This is the start of #169 however I am not sure if it is the correct way to go. 

I cannot check if the edits I've made actually address the punning. Reasoning being that even if I load sweetAll.ttl via the local file, I am quite certain that the imported ontologies are loaded from the http://sweetontology.net/... IRI instead of the local file. 

Having searched on the protege mailing list and not been successful tracking down an answer, I'm going to ask what needs to be done to force the imports to be loaded from local disk. I'll write back here with any result.  