### PR TITLE
ISSUE-181 Annotating Geologic Feature and dissassociating from Realm

### DIFF
--- a/src/realmGeol.ttl
+++ b/src/realmGeol.ttl
@@ -170,7 +170,7 @@ soreag:GeologicFeature rdf:type owl:Class ;
                      dcterms:contributor [
                         a sdo:Organization ;
                         sdo:name "Geological Survey of Queensland" ;
-                        sdo:identifier <http://linked.data.gov.au/org/gsq> .
+                        sdo:identifier <http://linked.data.gov.au/org/gsq> ;
                      ] ;                                     
                      skos:altLabel "Geologic Feature" , "Geological Feature" ;
                      skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;

--- a/src/realmGeol.ttl
+++ b/src/realmGeol.ttl
@@ -2,6 +2,8 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix soreag: <http://sweetontology.net/realmGeol/> .
@@ -161,11 +163,19 @@ soreag:GeologicBoundary rdf:type owl:Class ;
 
 ###  http://sweetontology.net/realmGeol/GeologicFeature
 soreag:GeologicFeature rdf:type owl:Class ;
-                     rdfs:subClassOf sorea:PlanetaryRealm ,
-                                     [ rdf:type owl:Restriction ;
+                     rdfs:subClassOf [ rdf:type owl:Restriction ;
                                        owl:onProperty sorel:hasRealm ;
                                        owl:allValuesFrom sorea:Geosphere
                                      ] ;
+                     dcterms:contributor [
+                        a sdo:Organization ;
+                        sdo:name "Geological Survey of Queensland" ;
+                        sdo:identifier <http://linked.data.gov.au/org/gsq> .
+                     ] ;                                     
+                     skos:altLabel "Geologic Feature" , "Geological Feature" ;
+                     skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
+                     skos:example "Individuals: Lake Eyre Basin, Sarmatian Craton, Victoria Point Sandbar, Mount Erebus Volcano. Subclasses: Basin, Craton, Shield, Province, Sub-Province."@en ;
+                     skos:scopeNote "Geologic Features include sedimentary basins, stratigraphic units, non-stratigraphic (lithodemic) units, stratigraphic event features, provinces, tectonic and structural features, georesource accumulations, and geologically significant sites, among others"@en ;
                      rdfs:label "geologic feature"@en .
 
 


### PR DESCRIPTION
I have added standard SKOS annotation properties to Geologic Feature and removed the statement making it a subclass of `sorea:PlanetaryRealm`.

These changes follow discussion at Issue #181 

If this PR is merged, the intention of the Geological Survey of Queensland is to flesh out the subclasses of Geologic Feature - both the range and their details. We will also consider improving the positioning of Geologic Feature within the total SWEET ontology since the relationship to `sorea:PlanetaryRealm` will have been broken.