### PR TITLE
align geologic feature defn with guidance

### DIFF
--- a/src/realmGeol.ttl
+++ b/src/realmGeol.ttl
@@ -166,18 +166,23 @@ soreag:GeologicFeature rdf:type owl:Class ;
                      rdfs:subClassOf [ rdf:type owl:Restriction ;
                                        owl:onProperty sorel:hasRealm ;
                                        owl:allValuesFrom sorea:Geosphere
-                                     ] ;
-                     dcterms:contributor [
-                        a sdo:Organization ;
-                        sdo:name "Geological Survey of Queensland" ;
-                        sdo:identifier <http://linked.data.gov.au/org/gsq> ;
-                     ] ;                                     
+                                     ] ;                                    
                      skos:altLabel "Geologic Feature" , "Geological Feature" ;
-                     skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
+                     skos:definition [
+                       rdfs:comment "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
+                       dcterms:created "2020-01-21"^^xsd:date ;
+                       dcterms:modified "2020-01-21"^^xsd:date ;
+                       dcterms:creator <http://linked.data.gov.au/org/gsq> ;
+                     ] ;
                      skos:example "Individuals: Lake Eyre Basin, Sarmatian Craton, Victoria Point Sandbar, Mount Erebus Volcano. Subclasses: Basin, Craton, Shield, Province, Sub-Province."@en ;
                      skos:scopeNote "Geologic Features include sedimentary basins, stratigraphic units, non-stratigraphic (lithodemic) units, stratigraphic event features, provinces, tectonic and structural features, georesource accumulations, and geologically significant sites, among others"@en ;
                      rdfs:label "geologic feature"@en .
 
+<http://linked.data.gov.au/org/gsq>
+  a sdo:Organization ;
+  sdo:name "Geological Survey of Queensland" ;
+  sdo:identifier <http://linked.data.gov.au/org/gsq> ;
+.
 
 ###  http://sweetontology.net/realmGeol/GeologicProvince
 soreag:GeologicProvince rdf:type owl:Class ;


### PR DESCRIPTION
Guidance as per https://github.com/ESIPFed/sweet/wiki/SWEET-Annotation-Convention. This PR makes it clear that it was the definition that was contributed to by GSQ, as opposed to a general contributor note on the class as a whole.

This sets a precedence for the future (lots of - 50+) definitions that we'll be pushing up shortly where the definition provider (creator) is some academic author with GSQ playing the role of contributor.

Also, the node for the GSQ is called out with its own URI, as opposed to using a Blank Node, since we will need repeated references to GSQ and this will therefore better link things back than a series of un-related BNs all with identical `sdo:name` & `sdo:identifier` properties.