### PR TITLE
Geofeature defs

### DIFF
--- a/src/realmGeol.ttl
+++ b/src/realmGeol.ttl
@@ -741,7 +741,11 @@ soreag:GeologicFeature rdf:type owl:Class ;
                                        ] ;
                        dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
                        skos:altLabel "Geological Feature"@en ;
-                       skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
+                       skos:definition [ dcterms:created "2020-01-21"^^xsd:date ;
+                                         dcterms:creator <http://linked.data.gov.au/org/gsq> ;
+                                         dcterms:modified "2020-01-21"^^xsd:date ;
+                                         rdfs:comment "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en
+                                       ] ;
                        skos:example "Individuals: Lake Eyre Basin, Sarmatian Craton, Victoria Point Sandbar, Mount Erebus Volcano. Subclasses: Basin, Craton, Shield, Province, Sub-Province"@en ;
                        skos:prefLabel "cechy geologiczne"@pl ,
                                       "geologic feature"@en ;

--- a/src/realmGeol.ttl
+++ b/src/realmGeol.ttl
@@ -28,6 +28,7 @@
                                       owl:versionIRI <http://sweetontology.net/realmGeol/3.5.0> ;
                                       dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
                                       dcterms:modified "2020-02-21"^^xsd:date ;
+                                      rdfs:comment "This ontology includes structural parts of the Earth's geosphere and classes of geologic feature within it"@en ;
                                       rdfs:label "SWEET Ontology Realm Geologic" ;
                                       owl:versionInfo "3.5.0" ;
                                       prof:isProfileOf <http://sweetontology.net/realmGeol> .
@@ -769,10 +770,16 @@ soreag:GeologicStructure rdf:type owl:Class ;
 soreag:GeologicalHeritageSite rdf:type owl:Class ;
                               rdfs:subClassOf soreag:GeologicallySignificantSite ;
                               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
-                              dcterms:source [ ] ,
-[ ] ;
-skos:definition "Geological Heritage Sites (formerly known as Geological Monuments) display geological features that are so outstanding or so rare that they form part of our natural heritage, requiring recognition, description and protection, for education, research and their geotourism potential. They show evidence of the geological processes that have occurred on Earth, and of the plants and animals that have lived on it. These sites include landforms, rock outcrops, river banks, sea cliffs and shore platforms, and are, in part, represented in road cuttings, mines, quarries and other excavations. (Geological Society of Australia)"@en ;
-skos:prefLabel "geological heritage site"@en .
+                              dcterms:source [ rdf:type sohur:Publication ;
+                                               dcterms:creator "Geological Society of Australia" ;
+                                               dcterms:date "2020"^^xsd:gYear ;
+                                               dcterms:publisher "Geological Society of Australia" ;
+                                               dcterms:title "ACT Geoheritage" ;
+                                               dcterms:type wiki:Q35127 ;
+                                               sdo:url <https://www.gsa.org.au/Public/Geoheritage/ACT_Geoheritage/Public/Geoheritage/ACT_Geoheritage.aspx?hkey=396c84ce-9cb1-47d9-91c7-5770f97a8896>
+                                             ] ;
+                              skos:definition "Geological Heritage Sites (formerly known as Geological Monuments) display geological features that are so outstanding or so rare that they form part of our natural heritage, requiring recognition, description and protection, for education, research and their geotourism potential. They show evidence of the geological processes that have occurred on Earth, and of the plants and animals that have lived on it. These sites include landforms, rock outcrops, river banks, sea cliffs and shore platforms, and are, in part, represented in road cuttings, mines, quarries and other excavations. (Geological Society of Australia)"@en ;
+                              skos:prefLabel "geological heritage site"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GeologicallySignificantSite
@@ -790,7 +797,7 @@ soreag:Geopark rdf:type owl:Class ;
                rdfs:subClassOf soreag:GeologicallySignificantSite ;
                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
                dcterms:source <https://unesdoc.unesco.org/ark:/48223/pf0000150007> ;
-               skos:definition "A Geopark is a nationally protected area containing a number of geological heritage sites of particular importance, rarity or aesthetic appeal. These Earth heritage sites are part of an integrated concept of protection, education and sustainable development. (UNESCO; December 2019)"@en ;
+               skos:definition "A Geopark is a nationally protected area containing a number of geological heritage sites of particular importance, rarity or aesthetic appeal. These Earth heritage sites are part of an integrated concept of protection, education and sustainable development. (UNESCO, 2006)"@en ;
                skos:example """Four UNESCO-designated Geoparks (from http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/) are: 
 
               1. Papuk UNESCO Global Geopark in Slavonia, Croatia (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/croatia/papuk/); 
@@ -840,10 +847,16 @@ soreag:GeosphereLayer rdf:type owl:Class ;
 soreag:Geotrail rdf:type owl:Class ;
                 rdfs:subClassOf soreag:GeologicallySignificantSite ;
                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
-                dcterms:source [ ] ,
-[ ] ;
-skos:definition "Geotrails aim to provide a tourism experience linking an area’s geology and landscape (i.e., its geological heritage features, including mining heritage) to its biodiversity and cultural history. (Geological Society of Australia)"@en ;
-skos:prefLabel "geotrail"@en .
+                dcterms:source [ rdf:type sohur:Publication ;
+                                 dcterms:creator "Geological Society of Australia" ;
+                                 dcterms:date "2020"^^xsd:gYear ;
+                                 dcterms:publisher "Geological Society of Australia" ;
+                                 dcterms:title "Geotourism and Geotrails" ;
+                                 dcterms:type wiki:Q35127 ;
+                                 sdo:url <https://www.gsa.org.au/Public/Geotourism/Geotourism%20and%20Geotrails/Public/Geotourism/Geotourism%20and%20Geotrails.aspx?hkey=f3ee82ea-de9a-44eb-82f7-377d2d28d2ba>
+                               ] ;
+                skos:definition "Geotrails aim to provide a tourism experience linking an area’s geology and landscape (i.e., its geological heritage features, including mining heritage) to its biodiversity and cultural history. (Geological Society of Australia)"@en ;
+                skos:prefLabel "geotrail"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GiantDikeSwarm
@@ -1554,6 +1567,7 @@ sdo:Person rdf:type owl:Class .
 <http://linked.data.gov.au/org/gsq> rdf:type owl:NamedIndividual ,
                                              sdo:Organization ;
                                     sdo:email <mailto:geological_info@dnrme.qld.gov.au> ;
+                                    sdo:identifier <http://linked.data.gov.au/org/gsq> ;
                                     sdo:name "Geological Survey of Queensland" .
 
 
@@ -1571,8 +1585,8 @@ sdo:Person rdf:type owl:Class .
                                                 dcterms:date "1996"^^xsd:gYear ;
                                                 dcterms:identifier "Record 1996/30" ;
                                                 dcterms:publisher "Geoscience Australia" ;
-                                                dcterms:title "Australian Crustal Elements Map" ;
-                                                dcterms:type "" .
+                                                dcterms:title "Guide to Using the Australian Crustal Elements Map" ;
+                                                dcterms:type biblio:Report .
 
 
 ###  http://pid.geoscience.gov.au/dataset/ga/70149
@@ -1839,13 +1853,26 @@ soreag:Crust rdf:type owl:NamedIndividual .
                                         sdo:name "Nicholas J. Car" .
 
 
+###  https://unesdoc.unesco.org/ark:/48223/pf0000150007
+<https://unesdoc.unesco.org/ark:/48223/pf0000150007> rdf:type owl:NamedIndividual ,
+                                                              sohur:Publication ;
+                                                     dcterms:creator "Lesvos Petrified Forest Geopark (Greece)" ;
+                                                     dcterms:date "2006"^^xsd:gYear ;
+                                                     dcterms:identifier "0000150007" ,
+                                                                        "SC/EES/2006/PI/GEOPARKS/1" ;
+                                                     dcterms:title "Global Geoparks Network" ;
+                                                     dcterms:type biblio:Report .
+
+
 ###  https://www.elsevier.com/books/the-geologic-time-scale-2012/gradstein/978-0-444-59425-9
 <https://www.elsevier.com/books/the-geologic-time-scale-2012/gradstein/978-0-444-59425-9> rdf:type owl:NamedIndividual ,
                                                                                                    sohur:Publication ;
-                                                                                          dcterms:creator "F.M. Gradstein" ,
-                                                                                                          "Gabi Ogg" ,
-                                                                                                          "J.G. Ogg" ,
-                                                                                                          "Mark Schmitz" ;
+                                                                                          dcterms:creator [ rdf:type rdf:Seq ;
+                                                                                                            rdf:_1 "F.M. Gradstein" ;
+                                                                                                            rdf:_2 "J.G. Ogg" ;
+                                                                                                            rdf:_3 "Mark Schmitz" ;
+                                                                                                            rdf:_4 "Gabi Ogg"
+                                                                                                          ] ;
                                                                                           dcterms:date "2012-07-31"^^xsd:date ;
                                                                                           dcterms:identifier "ISBN: 978-0-444-59448-8" ;
                                                                                           dcterms:publisher "Elsevier, Amsterdam" ;
@@ -1853,47 +1880,6 @@ soreag:Crust rdf:type owl:NamedIndividual .
                                                                                           dcterms:type biblio:Book ,
                                                                                                        wiki:Q571 .
 
-
-[ rdf:type sohur:Publication ;
-  dcterms:creator "Geological Society of Australia" ;
-  dcterms:date "2020"^^xsd:gYear ;
-  dcterms:publisher "Geological Society of Australia" ;
-  dcterms:title "ACT Geoheritage" ;
-  dcterms:type wiki:Q35127 ;
-  sdo:url <https://www.gsa.org.au/Public/Geoheritage/ACT_Geoheritage/Public/Geoheritage/ACT_Geoheritage.aspx?hkey=396c84ce-9cb1-47d9-91c7-5770f97a8896>
-] .
-
-[ rdf:type sohur:Publication ;
-   dcterms:creator "Geological Society of Australia" ;
-   dcterms:date "2020"^^xsd:gYear ;
-   dcterms:publisher "Geological Society of Australia" ;
-   dcterms:title "ACT Geoheritage" ;
-   dcterms:type wiki:Q35127 ;
-   sdo:url <https://www.gsa.org.au/Public/Geoheritage/ACT_Geoheritage/Public/Geoheritage/ACT_Geoheritage.aspx?hkey=396c84ce-9cb1-47d9-91c7-5770f97a8896>
- ] .
-
-[ rdf:type sohur:Publication ;
-   dcterms:creator "Geological Society of Australia" ;
-   dcterms:date "2020"^^xsd:gYear ;
-   dcterms:publisher "Geological Society of Australia" ;
-   dcterms:title "Geotourism and Geotrails" ;
-   dcterms:type wiki:Q35127 ;
-   sdo:url <https://www.gsa.org.au/Public/Geotourism/Geotourism%20and%20Geotrails/Public/Geotourism/Geotourism%20and%20Geotrails.aspx?hkey=f3ee82ea-de9a-44eb-82f7-377d2d28d2ba>
- ] .
-
-[ rdf:type sohur:Publication ;
-   dcterms:creator "Geological Society of Australia" ;
-   dcterms:date "2020"^^xsd:gYear ;
-   dcterms:publisher "Geological Society of Australia" ;
-   dcterms:title "Geotourism and Geotrails" ;
-   dcterms:type wiki:Q35127 ;
-   sdo:url <https://www.gsa.org.au/Public/Geotourism/Geotourism%20and%20Geotrails/Public/Geotourism/Geotourism%20and%20Geotrails.aspx?hkey=f3ee82ea-de9a-44eb-82f7-377d2d28d2ba>
- ] .
-
-[ rdf:type sdo:Organization ;
-   sdo:identifier <http://linked.data.gov.au/org/gsq> ;
-   sdo:name "Geological Survey of Queensland"
- ] .
 
 #################################################################
 #    Annotations

--- a/src/realmGeol.ttl
+++ b/src/realmGeol.ttl
@@ -1,40 +1,271 @@
 @prefix : <http://sweetontology.net/realmGeol/> .
+@prefix geo: <http://www.opengis.net/ont/geosparql#> .
+@prefix npg: <http://ns.nature.com/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sdo: <https://schema.org/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix soreag: <http://sweetontology.net/realmGeol/> .
-@prefix somarock: <http://sweetontology.net/matrRock/> .
-@prefix soprop: <http://sweetontology.net/propSpace/> .
+@prefix prof: <http://www.w3.org/ns/dx/prof/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix sorel: <http://sweetontology.net/rela/> .
-@prefix sorelph: <http://sweetontology.net/relaPhysical/> .
-@prefix sorelsp: <http://sweetontology.net/relaSpace/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wiki: <https://www.wikidata.org/wiki/> .
+@prefix sohur: <http://sweetontology.net/humanResearch/> .
 @prefix sorea: <http://sweetontology.net/realm/> .
+@prefix sorel: <http://sweetontology.net/rela/> .
+@prefix biblio: <http://purl.org/net/biblio#> .
+@prefix soprop: <http://sweetontology.net/propSpace/> .
+@prefix soreag: <http://sweetontology.net/realmGeol/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix sorelph: <http://sweetontology.net/relaPhysical/> .
 @prefix sorelsc: <http://sweetontology.net/relaSci/> .
+@prefix sorelsp: <http://sweetontology.net/relaSpace/> .
+@prefix sweetgf: <http://linked.data.gov.au/def/sweetgeofeatures/> .
+@prefix somarock: <http://sweetontology.net/matrRock/> .
 @base <http://sweetontology.net/realmGeol> .
 
 <http://sweetontology.net/realmGeol> rdf:type owl:Ontology ;
-                                      owl:imports <http://sweetontology.net/matrRock> ,
-                                                  <http://sweetontology.net/propSpace> ,
-                                                  <http://sweetontology.net/realm> ,
-                                                  <http://sweetontology.net/rela> ,
-                                                  <http://sweetontology.net/relaPhysical> ,
-                                                  <http://sweetontology.net/relaSci> ,
-                                                  <http://sweetontology.net/relaSpace> ;
-                                      rdfs:label "SWEET Ontology Realm Geologic" ;
+                                      owl:versionIRI <http://sweetontology.net/realmGeol/3.5.0> ;
                                       dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
-                                      owl:versionInfo "3.5.0" .
+                                      dcterms:modified "2020-02-21"^^xsd:date ;
+                                      rdfs:label "SWEET Ontology Realm Geologic" ;
+                                      owl:versionInfo "3.5.0" ;
+                                      prof:isProfileOf <http://sweetontology.net/realmGeol> .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://ns.nature.com/terms/hasJournal
+npg:hasJournal rdf:type owl:AnnotationProperty .
+
+
+###  http://ns.nature.com/terms/issue
+npg:issue rdf:type owl:AnnotationProperty .
+
+
+###  http://ns.nature.com/terms/pages
+npg:pages rdf:type owl:AnnotationProperty .
+
+
+###  http://ns.nature.com/terms/volume
+npg:volume rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/conformsTo
+dcterms:conformsTo rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/contributor
+dcterms:contributor rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/created
+dcterms:created rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/creator
+dcterms:creator rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/date
+dcterms:date rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/description
+dcterms:description rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/format
+dcterms:format rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/identifier
+dcterms:identifier rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/license
+dcterms:license rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/modified
+dcterms:modified rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/publisher
+dcterms:publisher rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/source
+dcterms:source rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/title
+dcterms:title rdf:type owl:AnnotationProperty .
+
+
+###  http://purl.org/dc/terms/type
+dcterms:type rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_1
+rdf:_1 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_10
+rdf:_10 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_11
+rdf:_11 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_12
+rdf:_12 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_13
+rdf:_13 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_14
+rdf:_14 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_15
+rdf:_15 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_16
+rdf:_16 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_17
+rdf:_17 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_2
+rdf:_2 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_3
+rdf:_3 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_4
+rdf:_4 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_5
+rdf:_5 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_6
+rdf:_6 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_7
+rdf:_7 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_8
+rdf:_8 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#_9
+rdf:_9 rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2002/07/owl#minCardinality
+owl:minCardinality rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#altLabel
+skos:altLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#definition
+skos:definition rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#defintion
+skos:defintion rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#example
+skos:example rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#prefLabel
+skos:prefLabel rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/2004/02/skos/core#scopeNote
+skos:scopeNote rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/ns/dx/prof/hasArtifact
+prof:hasArtifact rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/ns/dx/prof/hasRole
+prof:hasRole rdf:type owl:AnnotationProperty .
+
+
+###  http://www.w3.org/ns/dx/prof/isProfileOf
+prof:isProfileOf rdf:type owl:AnnotationProperty .
+
+
+###  https://schema.org/affiliation
+sdo:affiliation rdf:type owl:AnnotationProperty .
+
+
+###  https://schema.org/email
+sdo:email rdf:type owl:AnnotationProperty .
+
+
+###  https://schema.org/identifier
+sdo:identifier rdf:type owl:AnnotationProperty .
+
+
+###  https://schema.org/lastReviewed
+sdo:lastReviewed rdf:type owl:AnnotationProperty .
+
+
+###  https://schema.org/name
+sdo:name rdf:type owl:AnnotationProperty .
+
+
+###  https://schema.org/url
+sdo:url rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Datatypes
+#################################################################
+
+###  http://www.w3.org/2001/XMLSchema#date
+xsd:date rdf:type rdfs:Datatype .
+
+
+###  http://www.w3.org/2001/XMLSchema#gYear
+xsd:gYear rdf:type rdfs:Datatype .
+
 
 #################################################################
 #    Object Properties
 #################################################################
 
+###  http://sweetontology.net/rela/hasPart
+sorel:hasPart rdf:type owl:ObjectProperty .
+
+
 ###  http://sweetontology.net/rela/hasRealm
 sorel:hasRealm rdf:type owl:ObjectProperty .
+
+
+###  http://sweetontology.net/rela/partOf
+sorel:partOf rdf:type owl:ObjectProperty .
 
 
 ###  http://sweetontology.net/relaPhysical/hasPlanetaryStructure
@@ -57,307 +288,1624 @@ sorelsp:hasUpperBoundary rdf:type owl:ObjectProperty .
 #    Classes
 #################################################################
 
+###  http://ns.nature.com/terms/Journal
+npg:Journal rdf:type owl:Class .
+
+
+###  http://sweetontology.net/humanResearch/Publication
+sohur:Publication rdf:type owl:Class .
+
+
+###  http://sweetontology.net/matrRock/Rock
+somarock:Rock rdf:type owl:Class .
+
+
 ###  http://sweetontology.net/realm/Geosphere
-sorea:Geosphere owl:equivalentClass soreag:SolidEarth .
+sorea:Geosphere rdf:type owl:Class ;
+                skos:altLabel "solid earth"@en ;
+                skos:prefLabel "geosphere"@en .
+
+
+###  http://sweetontology.net/realm/PlanetaryBoundary
+sorea:PlanetaryBoundary rdf:type owl:Class .
+
+
+###  http://sweetontology.net/realm/PlanetaryLayer
+sorea:PlanetaryLayer rdf:type owl:Class .
+
+
+###  http://sweetontology.net/realm/PlanetaryRealm
+sorea:PlanetaryRealm rdf:type owl:Class .
 
 
 ###  http://sweetontology.net/realm/PlanetarySurface
-sorea:PlanetarySurface owl:disjointWith soreag:Subsurface .
+sorea:PlanetarySurface rdf:type owl:Class ;
+                       owl:disjointWith soreag:Subsurface .
+
+
+###  http://sweetontology.net/realmGeol/AbundanceZone
+soreag:AbundanceZone rdf:type owl:Class ;
+                     rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                     dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                     dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                     skos:definition "The body of strata in which the abundance of a particular taxon or specified group of taxa is significantly greater than is usual in the adjacent parts of the section. (ICS, Online, December 2019)"@en ;
+                     skos:prefLabel "abundance zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Anticline
+soreag:Anticline rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:StructuralFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.glossaryofgeology.org> ;
+                 skos:definition "A fold, generally convex upward, whose core contains the stratigraphically older rocks. (Neuendorf et al., 2011)"@en ;
+                 skos:prefLabel "anticline"@en .
+
+
+###  http://sweetontology.net/realmGeol/Anticlinorium
+soreag:Anticlinorium rdf:type owl:Class ;
+                     rdfs:subClassOf soreag:StructuralFeature ;
+                     dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                     dcterms:source <http://www.glossaryofgeology.org> ;
+                     skos:definition "A composite anticlinal structure of regional extent composed of lesser folds. (Neuendorf et al., 2011)"@en ;
+                     skos:prefLabel "anticlinorium"@en .
+
+
+###  http://sweetontology.net/realmGeol/Antiform
+soreag:Antiform rdf:type owl:Class ;
+                rdfs:subClassOf soreag:StructuralFeature ;
+                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                dcterms:source <http://www.glossaryofgeology.org> ;
+                skos:definition "Any convex-upward, concave downward fold. The term is usually used when the folded layers do not possess a stratigraphic order, when the stratigraphic order of the folded layers is not known, or when the fold core also contains the stratigraphically younger rock. (Neuendorf et al., 2011)"@en ;
+                skos:prefLabel "antiform"@en .
+
+
+###  http://sweetontology.net/realmGeol/AntiformalStack
+soreag:AntiformalStack rdf:type owl:Class ;
+                       rdfs:subClassOf soreag:StructuralFeature ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       dcterms:source <http://www.glossaryofgeology.org> ;
+                       skos:definition "A duplex in which the trailing branch lines coincide and the leading branch lines either nearly coincide or lie vertically above each other. This results in a stack of horses and leads to a local culmination in thrust sheet. (Neuendorf et al. (2011) citing Boyer & Elliott (1982))"@en ;
+                       skos:prefLabel "antiformal stack"@en .
+
+
+###  http://sweetontology.net/realmGeol/Arch
+soreag:Arch rdf:type owl:Class ;
+            rdfs:subClassOf soreag:StructuralFeature ;
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <http://www.glossaryofgeology.org> ;
+            skos:definition "A broad, open anticlinal fold on a regional scale; it is usually a basement doming. (Neuendorf et al., 2011)"@en ;
+            skos:prefLabel "arch"@en .
+
+
+###  http://sweetontology.net/realmGeol/AssemblageZone
+soreag:AssemblageZone rdf:type owl:Class ;
+                      rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                      dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                      dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                      skos:definition "The body of strata characterized by an assemblage of three or more fossil taxa that, taken together, distinguishes it in biostratigraphic character from adjacent strata. (ICS, Online, December 2019)"@en ;
+                      skos:prefLabel "assemblage zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/AssociationZone
+soreag:AssociationZone rdf:type owl:Class ;
+                       rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       dcterms:source <https://doi.org/10.1016/j.revpalbo.2014.04.002> ,
+                                      <https://doi.org/10.1080/01916122.2012.718609> ;
+                       skos:definition "The body of strata between two designated biostratigraphical horizons, which represent the boundaries of the unit and separate it from any preceding or succeeding biozone. These bounding horizons may be delimited individually by: the level of the first stratigraphical appearance (lowermost or oldest occurrence) of a specified taxon (species, genus) in any one stratigraphical section; or another specified biostratigraphical feature considered to approximate a time horizon. The zone is further delimited by specified taxa (preferably, at least three), which have first appearances within the zone. (de Jersey & McKellar, 2013; Bomfleur et al., 2014)"@en ;
+                       skos:prefLabel "association zone"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Asthenosphere
 soreag:Asthenosphere rdf:type owl:Class ;
-                   owl:equivalentClass soreag:UpperMantleFlowing ;
-                   rdfs:subClassOf soreag:UpperMantle ;
-                   rdfs:label "asthenosphere"@en .
+                     owl:equivalentClass soreag:UpperMantleFlowing ;
+                     rdfs:subClassOf soreag:UpperMantle ;
+                     rdfs:label "asthenosphere"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Basement
 soreag:Basement rdf:type owl:Class ;
-              rdfs:subClassOf soreag:GeologicStructure ;
-              rdfs:label "basement"@en .
+                rdfs:subClassOf soreag:GeologicStructure ;
+                rdfs:label "basement"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Batholith
 soreag:Batholith rdf:type owl:Class ;
-               rdfs:subClassOf soreag:PlutonicStructure ;
-               rdfs:label "batholith"@en .
+                 rdfs:subClassOf soreag:PlutonicStructure ;
+                 rdfs:label "batholith"@en .
+
+
+###  http://sweetontology.net/realmGeol/Bed
+soreag:Bed rdf:type owl:Class ;
+           rdfs:subClassOf soreag:LithostratigraphicUnit ;
+           dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+           dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                          <https://doi.org/10.1080/08120098508729316> ,
+                          <https://doi.org/10.1130/9780813774022> ;
+           skos:definition "Bed (Beds) is the smallest formal unit in the hierarchy of sedimentary lithostratigraphic units, e.g. a single stratum lithologically distinguishable from other layers above and below (Salvador, 2013; ICS Online, January 2020). Customarily, only distinctive beds (commonly known as marker beds), which are particularly useful for stratigraphic purposes, like correlation or reference, are given proper names and considered formal lithostratigraphic units (Staines, 1985)"@en ;
+           skos:prefLabel "bed"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Bedrock
 soreag:Bedrock rdf:type owl:Class ;
-             rdfs:subClassOf soreag:GeosphereLayer ;
-             rdfs:label "bedrock"@en .
+               rdfs:subClassOf soreag:GeosphereLayer ;
+               rdfs:label "bedrock"@en .
+
+
+###  http://sweetontology.net/realmGeol/Beds
+soreag:Beds rdf:type owl:Class ;
+            rdfs:subClassOf soreag:LithostratigraphicUnit ;
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <https://doi.org/10.1080/08120098508729316> ;
+            skos:definition "beds (uncapitalised): an informal unit applied to a sequence of poorly known strata until further work is carried out, as advised in the Field Geologist’s Guide to Lithostratigraphic Nomenclature in Australia (Staines, 1985), and endorsed by the Stratigraphic Nomenclature Committee, Geological Society of Australia."@en ;
+            skos:prefLabel "beds"@en .
+
+
+###  http://sweetontology.net/realmGeol/BiostratigraphicUnit
+soreag:BiostratigraphicUnit rdf:type owl:Class ;
+                            rdfs:subClassOf soreag:StratigraphicUnit ;
+                            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                            dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                            skos:definition "Biostratigraphic units/Biostratigraphic Zones (biozones) are bodies of strata that are defined or characterized on the basis of their contained fossils.  The different types have no hierarchical significance, and are not based on mutually exclusive criteria. (ICS, Online, December 2019)"@en ;
+                            skos:prefLabel "biostratigraphic unit"@en .
+
+
+###  http://sweetontology.net/realmGeol/Block
+soreag:Block rdf:type owl:Class ;
+             rdfs:subClassOf soreag:StructuralFeature ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <http://www.glossaryofgeology.org> ;
+             skos:altLabel "fault block"@en ;
+             skos:definition " A block of the crust that has been displaced by movement on a fault. (Neuendorf et al., 2011)"@en ;
+             skos:prefLabel "block"@en .
 
 
 ###  http://sweetontology.net/realmGeol/BrittleDuctileTransitionZone
 soreag:BrittleDuctileTransitionZone rdf:type owl:Class ;
-                                  rdfs:subClassOf soreag:Crust ;
-                                  rdfs:label "brittle ductile transition zone"@en .
+                                    rdfs:subClassOf soreag:Crust ;
+                                    rdfs:label "brittle ductile transition zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/ChronostratigraphicUnit
+soreag:ChronostratigraphicUnit rdf:type owl:Class ;
+                               rdfs:subClassOf soreag:StratigraphicUnit ;
+                               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                               dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                              <https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.605.7824> ,
+                                              <https://doi.org/10.1306/05230505015> ;
+                               skos:definition "As the term implies, Chronostratigraphic Units are Time-Rock Units. They are bodies of rocks, layered or unlayered, that were formed during a specified interval of geologic time. [The units of geologic time during which chronostratigraphic units were formed are called geochronologic (geological-time) units.] (ICS, Online, December, 2019). NB: The North American Stratigraphic Code (2005) and Owen (2009) advise that geochronologic units should only be associated with Lithodemic (non-stratigraphic) Units."@en ;
+                               skos:prefLabel "chronostratigraphic unit"@en .
+
+
+###  http://sweetontology.net/realmGeol/Complex
+soreag:Complex rdf:type owl:Class ;
+               rdfs:subClassOf soreag:LithodemicFeature ;
+               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+               dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+               skos:definition "In the classification of Kumpulainen (2016), a complex is a non-ranked lithodemic unit that corresponds to a suite or supersuite. Its usage applies to the organisation and classification of an assemblage of two or more genetically different rock types (i.e. igneous, metamorphic and/or sedimentary). For example, a tectonic amalgamation of igneous, sedimentary and metamorphic rocks may form a structural complex; and a volcanic complex may comprise extrusive, sedimentary and the related intrusive components."@en ;
+               skos:prefLabel "complex"@en .
+
+
+###  http://sweetontology.net/realmGeol/ConcurrentRangeZone
+soreag:ConcurrentRangeZone rdf:type owl:Class ;
+                           rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                           dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                           dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                           skos:definition "The body of strata including the overlapping parts of the range zones of two specified taxa. (ICS, Online, December 2019)"@en ;
+                           skos:prefLabel "concurrent range zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Continent
+soreag:Continent rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:TectonicEntity ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.glossaryofgeology.org> ,
+                                <http://doi.org/10.22459/SN.08.2012> ;
+                 skos:definition "One of Earth’s major landmasses (or former major landmasses), including continental shelves. (Neuendorf et al., 2011; Blewett, 2012). The Australian Continent, as an example, is divided into fundamental geological elements embracing geological provinces."@en ;
+                 skos:prefLabel "continent"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Continental
 soreag:Continental rdf:type owl:Class ;
-                 rdfs:subClassOf sorea:PlanetaryRealm ;
-                 rdfs:label "continental"@en .
+                   rdfs:subClassOf sorea:PlanetaryRealm ;
+                   rdfs:label "continental"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Core
 soreag:Core rdf:type owl:Class ;
-          rdfs:subClassOf soreag:GeosphereLayer ;
-          rdfs:label "core"@en .
+            rdfs:subClassOf soreag:GeosphereLayer ;
+            rdfs:label "core"@en .
 
 
 ###  http://sweetontology.net/realmGeol/CoreMantleBoundary
 soreag:CoreMantleBoundary rdf:type owl:Class ;
-                        owl:equivalentClass soreag:GuttenburgDiscontinuity ;
-                        rdfs:label "core mantle boundary"@en .
+                          owl:equivalentClass soreag:GuttenburgDiscontinuity ;
+                          rdfs:subClassOf soreag:GeologicBoundary ;
+                          rdfs:label "core mantle boundary"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Cover
 soreag:Cover rdf:type owl:Class ;
-           rdfs:subClassOf soreag:GeologicStructure ;
-           rdfs:label "cover"@en .
+             rdfs:subClassOf soreag:GeologicStructure ;
+             rdfs:label "cover"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Crust
 soreag:Crust rdf:type owl:Class ;
-           owl:equivalentClass soreag:SkinLayer ;
-           rdfs:subClassOf soreag:GeosphereLayer ,
-                           [ rdf:type owl:Restriction ;
-                             owl:onProperty sorelsp:hasLowerBoundary ;
-                             owl:allValuesFrom soreag:Moho
-                           ] ;
-           rdfs:label "crust"@en .
+             owl:equivalentClass soreag:SkinLayer ;
+             rdfs:subClassOf soreag:GeosphereLayer ,
+                             [ rdf:type owl:Restriction ;
+                               owl:onProperty sorelsp:hasLowerBoundary ;
+                               owl:allValuesFrom soreag:Moho
+                             ] .
 
 
 ###  http://sweetontology.net/realmGeol/CrustMantleBoundary
 soreag:CrustMantleBoundary rdf:type owl:Class ;
-                         owl:equivalentClass soreag:Moho ;
-                         rdfs:label "crust mantle boundary"@en .
+                           owl:equivalentClass soreag:Moho ;
+                           rdfs:subClassOf soreag:GeologicBoundary ;
+                           rdfs:label "crust mantle boundary"@en .
+
+
+###  http://sweetontology.net/realmGeol/CrustalElement
+soreag:CrustalElement rdf:type owl:Class ;
+                      rdfs:subClassOf soreag:GeophysicalDomain ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty sorel:partOf ;
+                                        owl:hasValue soreag:Crust
+                                      ] ;
+                      dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                      dcterms:source <http://pid.geoscience.gov.au/dataset/ga/14909> ;
+                      skos:definition "Crustal Elements are geophysical domains that represent upper-crustal segments showing some overall commonality of geophysical properties, primarily magnetic and gravity data sets. Crustal elements are not geologically defined features, such as basement provinces. The latter are defined on the basis of geological criteria and are three-dimensional bodies that have a definite thickness and represent time-rock units whose maximum and minimum ages are generally, but not always, well established. Some crustal elements could represent a set of overlying or overlapping basement provinces. (Shaw et al., 1996)"@en ;
+                      skos:prefLabel "crustal element"@en .
 
 
 ###  http://sweetontology.net/realmGeol/DLayer
 soreag:DLayer rdf:type owl:Class ;
-            rdfs:subClassOf soreag:Mantle ;
-            rdfs:label "d layer"@en .
+              rdfs:subClassOf soreag:Mantle ;
+              rdfs:label "d layer"@en .
+
+
+###  http://sweetontology.net/realmGeol/DenudationalFeature
+soreag:DenudationalFeature rdf:type owl:Class ;
+                           rdfs:subClassOf soreag:StructuralFeature ;
+                           dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                           dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                           skos:definition "Structures shaped by weathering and erosion; include inlier, outlier, window, klippe, unconformity and peneplain (Kumpulainen, 2017)"@en ;
+                           skos:prefLabel "denudational feature"@en .
+
+
+###  http://sweetontology.net/realmGeol/Depression
+soreag:Depression rdf:type owl:Class ;
+                  rdfs:subClassOf soreag:StructuralFeature ;
+                  dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                  dcterms:source <http://www.glossaryofgeology.org> ;
+                  skos:definition "A structurally low area formed in the crust, with various mechanisms of formation. (Modified from Neuendorf et al., 2011)"@en ;
+                  skos:prefLabel "depression"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Dike
 soreag:Dike rdf:type owl:Class ;
-          rdfs:subClassOf soreag:PlutonicStructure ;
-          rdfs:label "dike"@en .
+            rdfs:subClassOf soreag:PlutonicStructure ;
+            rdfs:label "dike"@en .
 
 
-###  http://sweetontology.net/realmGeol/Fabric
-soreag:Fabric rdf:type owl:Class ;
-            rdfs:subClassOf soprop:Configuration ;
-            rdfs:label "fabric"@en .
+###  http://sweetontology.net/realmGeol/Dome
+soreag:Dome rdf:type owl:Class ;
+            rdfs:subClassOf soreag:StructuralFeature ;
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <http://www.glossaryofgeology.org> ;
+            skos:definition "An uplift or anticlinal structure, either circular or elliptical in outline, in which the rocks dip gently away in all directions. A dome may be small or many kilometers in diameter. Domes include diapirs, volcanic domes, and cratonic uplifts. (Neuendorf et al., 2011)"@en ;
+            skos:prefLabel "dome"@en .
+
+
+###  http://sweetontology.net/realmGeol/Duplex
+soreag:Duplex rdf:type owl:Class ;
+              rdfs:subClassOf soreag:StructuralFeature ;
+              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+              dcterms:source <http://www.glossaryofgeology.org> ;
+              skos:altLabel "Duplex Fault Zone"@en ;
+              skos:definition "A structural complex consisting of a roof thrust at the top and a floor thrust at the base, within which a suite of more steeply dipping imbricate thrust faults thicken and shorten the intervening panel of rock (Neuendorf et al. (2011) citing Dahlstrom (1970), Boyer (1976))"@en ;
+              skos:prefLabel "duplex"@en .
+
+
+###  http://sweetontology.net/realmGeol/Embayment
+soreag:Embayment rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:StructuralFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.glossaryofgeology.org> ;
+                 skos:definition "A downwarped area containing stratified rocks, either sedimentary or volcanic or both, that extends into a terrain of other rocks. (Neuendorf et al., 2011)"@en ;
+                 skos:prefLabel "embayment"@en .
+
+
+###  http://sweetontology.net/realmGeol/Escarpment
+soreag:Escarpment rdf:type owl:Class ;
+                  rdfs:subClassOf soreag:StructuralFeature ;
+                  dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                  dcterms:source <http://www.glossaryofgeology.org> ;
+                  skos:altLabel "cuesta"@en ,
+                                "scarpland"@en ;
+                  skos:definition "(a) A long, more or less continuous cliff or relatively steep slope facing in one general direction, breaking the continuity of the land by separating two levels of gently sloping surfaces, and produced by erosion or faulting. The term is often used synonymously with scarp, although escarpment is more often applied to a cliff formed by differential erosion;  (b) A steep, abrupt face of rock, often presented by the highest strata in a line of cliffs, and generally marking the outcrop of a resistant layer occurring in a series of gently dipping softer strata, specifically the steep face of a cuesta; (c) A term used loosely in Great Britain as a synonym of cuesta. (Neuendorf et al., 2011)"@en ;
+                  skos:prefLabel "cuesta"@es ,
+                                 "escarpment"@en .
+
+
+###  http://sweetontology.net/realmGeol/Fault
+soreag:Fault rdf:type owl:Class ;
+             rdfs:subClassOf soreag:StructuralFeature ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <http://www.glossaryofgeology.org> ;
+             skos:definition " A discrete surface or zone of discrete surfaces separating two rock masses across which one mass has slid past the other. (Neuendorf et al., 2011)"@en ;
+             skos:prefLabel "fault"@en .
+
+
+###  http://sweetontology.net/realmGeol/FaultScarp
+soreag:FaultScarp rdf:type owl:Class ;
+                  rdfs:subClassOf soreag:StructuralFeature ;
+                  dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                  dcterms:source <http://www.glossaryofgeology.org> ;
+                  skos:altLabel "cliff of displacement"@en ,
+                                "fault cliff"@en ,
+                                "fault escarpment"@en ;
+                  skos:definition "(a) A steep slope or cliff formed directly by movement along a fault and representing the exposed surface of the fault before modification by erosion and weathering. It is an initial landform; (b) A term used loosely in England for any scarp that is due to the presence of a fault, even though the relief may be erosional. (Neuendorf et al., 2011)"@en ;
+                  skos:prefLabel "fault scarp"@en .
+
+
+###  http://sweetontology.net/realmGeol/FaultSet
+soreag:FaultSet rdf:type owl:Class ;
+                rdfs:subClassOf soreag:StructuralFeature ;
+                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                dcterms:source <http://www.glossaryofgeology.org> ;
+                skos:definition " A group of faults that are parallel or nearly so, and that are related to a particular deformational episode. (Neuendorf et al., 2011)"@en ;
+                skos:prefLabel "fault set"@en .
+
+
+###  http://sweetontology.net/realmGeol/FaultSystem
+soreag:FaultSystem rdf:type owl:Class ;
+                   rdfs:subClassOf soreag:StructuralFeature ;
+                   dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                   dcterms:source <http://www.glossaryofgeology.org> ;
+                   skos:definition "(a) An array of interconnected and kinematically related faults; (b) Two or more geometrically related fault sets, e.g., a conjugate fault system. (Neuendorf et al., 2011)"@en ;
+                   skos:prefLabel "fault system"@en .
+
+
+###  http://sweetontology.net/realmGeol/FaultZone
+soreag:FaultZone rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:StructuralFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.glossaryofgeology.org> ;
+                 skos:definition "A fault that is expressed as a zone of numerous small fractures, breccia, and/or fault gouge. A fault zone may be as wide as hundreds of meters. (Neuendorf et al., 2011)"@en ;
+                 skos:prefLabel "fault zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Flow
+soreag:Flow rdf:type owl:Class ;
+            rdfs:subClassOf soreag:LithostratigraphicUnit ;
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+            skos:definition " A discrete extrusive volcanic body distinguishable by texture, composition, or other objective criteria. (ICS, Online, December 2019)"@en ;
+            skos:prefLabel "flow"@en .
+
+
+###  http://sweetontology.net/realmGeol/Fold
+soreag:Fold rdf:type owl:Class ;
+            rdfs:subClassOf soreag:StructuralFeature ;
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <http://www.glossaryofgeology.org> ;
+            skos:definition "A curve or bend of a planar structure, such as rock strata, bedding planes, foliation or cleavage. A fold is usually the product of deformation, involving the compression of strata, but may include primary structures, as its definition is descriptive, not genetic. (Neuendorf et al., 2011)"@en ;
+            skos:prefLabel "fold"@en .
+
+
+###  http://sweetontology.net/realmGeol/FoldBelt
+soreag:FoldBelt rdf:type owl:Class ;
+                rdfs:subClassOf soreag:StructuralFeature ;
+                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                dcterms:source <http://www.glossaryofgeology.org> ,
+                               <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                skos:altLabel "fold and thrust belt"@en ,
+                              "folded zone"@en ;
+                skos:definition "A region in Earth’s lithosphere characterised by compressional tectonics, involving folding (usually parellel) and thrusting (both causing crustal shortening). Fold belts generally develop in the foreland bordering an ogogenic zone that was initiated by convergence between two tectonic plates or major crustal blocks. (Modified from: Neuendorf et al., 2011; Allaby, 2013 (Oxford Dictionary of Geology and Earth Sciences))"@en ;
+                skos:prefLabel "fold belt"@en .
+
+
+###  http://sweetontology.net/realmGeol/Formation
+soreag:Formation rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:LithostratigraphicUnit ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                 skos:definition "The primary formal unit of lithostratigraphic classification. Formations are the only formal lithostratigraphic units into which the stratigraphic column everywhere should be divided completely on the basis of lithology. (ICS, Online, December 2019)"@en ;
+                 skos:prefLabel "formation"@en .
+
+
+###  http://sweetontology.net/realmGeol/GeoResourceAccumulation
+soreag:GeoResourceAccumulation rdf:type owl:Class ;
+                               rdfs:subClassOf soreag:GeologicFeature ;
+                               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                               skos:definition "Georesource accumulations are naturally occurring masses, volumes or concentrations of geological materials that have existing or potential economic value. These resources may include, but are not limited to, minerals (including coal), hydrocarbons, quarry resources and groundwater."@en ,
+                                               "Georesource accumulations are naturally occurring masses, volumes or concentrations of geological materials that have existing or potential economic value. These resources may include, but are not limited to, minerals (including coal), hydrocarbons, quarry resources and groundwater. (Definition created here)"@en ;
+                               skos:prefLabel "georesource accumulation"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GeologicBoundary
 soreag:GeologicBoundary rdf:type owl:Class ;
-                      rdfs:subClassOf sorea:PlanetaryBoundary ;
-                      rdfs:label "geologic boundary"@en .
+                        rdfs:subClassOf sorea:PlanetaryBoundary ;
+                        rdfs:label "geologic boundary"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GeologicFeature
 soreag:GeologicFeature rdf:type owl:Class ;
-                     rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                       owl:onProperty sorel:hasRealm ;
-                                       owl:allValuesFrom sorea:Geosphere
-                                     ] ;
-                     dcterms:contributor [
-                        a sdo:Organization ;
-                        sdo:name "Geological Survey of Queensland" ;
-                        sdo:identifier <http://linked.data.gov.au/org/gsq> ;
-                     ] ;                                     
-                     skos:altLabel "Geologic Feature" , "Geological Feature" ;
-                     skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
-                     skos:example "Individuals: Lake Eyre Basin, Sarmatian Craton, Victoria Point Sandbar, Mount Erebus Volcano. Subclasses: Basin, Craton, Shield, Province, Sub-Province."@en ;
-                     skos:scopeNote "Geologic Features include sedimentary basins, stratigraphic units, non-stratigraphic (lithodemic) units, stratigraphic event features, provinces, tectonic and structural features, georesource accumulations, and geologically significant sites, among others"@en ;
-                     rdfs:label "geologic feature"@en .
+                       rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                         owl:onProperty sorel:hasRealm ;
+                                         owl:allValuesFrom sorea:Geosphere
+                                       ] ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       skos:altLabel "Geological Feature"@en ;
+                       skos:definition "A geologic feature is a conceptual feature a that is hypothesized to exist coherently in the Earth that results from geological processes"@en ;
+                       skos:example "Individuals: Lake Eyre Basin, Sarmatian Craton, Victoria Point Sandbar, Mount Erebus Volcano. Subclasses: Basin, Craton, Shield, Province, Sub-Province"@en ;
+                       skos:prefLabel "cechy geologiczne"@pl ,
+                                      "geologic feature"@en ;
+                       skos:scopeNote "Geologic Features include sedimentary basins, stratigraphic units, non-stratigraphic (lithodemic) units, stratigraphic event features, provinces, tectonic and structural features, georesource accumulations, and geologically significant sites, among others"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GeologicProvince
 soreag:GeologicProvince rdf:type owl:Class ;
-                      rdfs:subClassOf soreag:GeologicFeature ;
-                      rdfs:label "geologic province"@en .
+                        rdfs:subClassOf soreag:TectonicEntity ;
+                        dcterms:contributor <http://linked.data.gov.au/def/gsq> ;
+                        skos:definition "Geologic provinces are tectonic entities that include cratons/shields (in the continental realm), orogens, sedimentary basins, and tectonised/metamorphosed and/or mineralised regions, as well as large igneous provinces (LIPs). (Definition created here)"@en ;
+                        skos:prefLabel "geologic province"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GeologicStructure
 soreag:GeologicStructure rdf:type owl:Class ;
-                       rdfs:subClassOf sorea:Geosphere ,
-                                       [ rdf:type owl:Restriction ;
-                                         owl:onProperty sorel:hasRealm ;
-                                         owl:allValuesFrom sorea:Geosphere
-                                       ] ;
-                       rdfs:label "geologic structure"@en .
+                         rdfs:subClassOf sorea:Geosphere ,
+                                         [ rdf:type owl:Restriction ;
+                                           owl:onProperty sorel:hasRealm ;
+                                           owl:allValuesFrom sorea:Geosphere
+                                         ] ;
+                         rdfs:label "geologic structure"@en .
+
+
+###  http://sweetontology.net/realmGeol/GeologicalHeritageSite
+soreag:GeologicalHeritageSite rdf:type owl:Class ;
+                              rdfs:subClassOf soreag:GeologicallySignificantSite ;
+                              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                              dcterms:source [ ] ,
+[ ] ;
+skos:definition "Geological Heritage Sites (formerly known as Geological Monuments) display geological features that are so outstanding or so rare that they form part of our natural heritage, requiring recognition, description and protection, for education, research and their geotourism potential. They show evidence of the geological processes that have occurred on Earth, and of the plants and animals that have lived on it. These sites include landforms, rock outcrops, river banks, sea cliffs and shore platforms, and are, in part, represented in road cuttings, mines, quarries and other excavations. (Geological Society of Australia)"@en ;
+skos:prefLabel "geological heritage site"@en .
+
+
+###  http://sweetontology.net/realmGeol/GeologicallySignificantSite
+soreag:GeologicallySignificantSite rdf:type owl:Class ;
+                                   rdfs:subClassOf soreag:GeologicFeature ,
+                                                   geo:Feature ;
+                                   dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                   dcterms:source <http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/frequently-asked-questions/what-is-a-unesco-global-geopark/> ;
+                                   skos:definition "Single, unified geographical areas where sites and landscapes of international geological significance are managed with a holistic concept of protection, education and sustainable development"@en ;
+                                   skos:prefLabel "geologically significant site"@en .
+
+
+###  http://sweetontology.net/realmGeol/Geopark
+soreag:Geopark rdf:type owl:Class ;
+               rdfs:subClassOf soreag:GeologicallySignificantSite ;
+               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+               dcterms:source <https://unesdoc.unesco.org/ark:/48223/pf0000150007> ;
+               skos:definition "A Geopark is a nationally protected area containing a number of geological heritage sites of particular importance, rarity or aesthetic appeal. These Earth heritage sites are part of an integrated concept of protection, education and sustainable development. (UNESCO; December 2019)"@en ;
+               skos:example """Four UNESCO-designated Geoparks (from http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/) are: 
+
+              1. Papuk UNESCO Global Geopark in Slavonia, Croatia (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/croatia/papuk/); 
+              2. Lesvos Island Global Geopark (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/greece/lesvos-island/); 
+              3. Muskauer Faltenboen / Łuk Mużakowa UNESCO Global Geopark, Germany & Poland (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/germanypoland/muskauer-faltenbogenluk-muzakowa/); and 
+              4. Alxa Desert UNESCO Global Geopark, China (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/china/alxa-desert/)."""@en ,
+                            """Four UNESCO-designated Geoparks (from http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/) are: 
+  
+  1. Papuk UNESCO Global Geopark in Slavonia, Croatia (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/croatia/papuk/); 
+  2. Lesvos Island Global Geopark (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/greece/lesvos-island/); 
+  3. Muskauer Faltenboen / Łuk Mużakowa UNESCO Global Geopark, Germany & Poland (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/germanypoland/muskauer-faltenbogenluk-muzakowa/); and 
+  4. Alxa Desert UNESCO Global Geopark, China (http://www.unesco.org/new/en/natural-sciences/environment/earth-sciences/unesco-global-geoparks/list-of-unesco-global-geoparks/china/alxa-desert/)."""@en ;
+               skos:prefLabel "geopark"@en .
+
+
+###  http://sweetontology.net/realmGeol/GeophysicalDomain
+soreag:GeophysicalDomain rdf:type owl:Class ;
+                         rdfs:subClassOf soreag:GeophysicalFeature ;
+                         dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                         dcterms:source <http://pid.geoscience.gov.au/dataset/ga/14909> ,
+                                        <https://doi.org/10.1016/j.tecto.2012.02.022> ;
+                         skos:defintion "Geophysical Domains are Geologic Features delimited by their geophysical properties, primarily magnetic and gravity properties or, in the case of Seismic Provinces, their crustal reflectivity. They represent discrete \"volumes\" of middle to lower crust. (Terminology based on usage of Shaw et al., 1996; Korsch et al., 2012)"@en ;
+                         skos:prefLabel "geophysical domain"@en .
+
+
+###  http://sweetontology.net/realmGeol/GeophysicalFeature
+soreag:GeophysicalFeature rdf:type owl:Class ;
+                          rdfs:subClassOf soreag:GeologicFeature ;
+                          dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                          dcterms:source <http://www.glossaryofgeology.org> ;
+                          skos:definition "A feature associated with, and interpreted from, the physical properties and processes of the Earth, e.g., seismology. (Neuendorf et al., 2011)"@en ;
+                          skos:prefLabel "geophysical feature"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GeosphereLayer
 soreag:GeosphereLayer rdf:type owl:Class ;
-                    rdfs:subClassOf sorea:PlanetaryLayer ,
-                                    soreag:Subsurface ,
-                                    [ rdf:type owl:Restriction ;
-                                      owl:onProperty sorel:hasRealm ;
-                                      owl:allValuesFrom sorea:Geosphere
-                                    ] ;
-                    rdfs:label "geosphere layer"@en .
+                      rdfs:subClassOf sorea:PlanetaryLayer ,
+                                      soreag:Subsurface ,
+                                      [ rdf:type owl:Restriction ;
+                                        owl:onProperty sorel:hasRealm ;
+                                        owl:allValuesFrom sorea:Geosphere
+                                      ] ;
+                      rdfs:label "geosphere layer"@en .
+
+
+###  http://sweetontology.net/realmGeol/Geotrail
+soreag:Geotrail rdf:type owl:Class ;
+                rdfs:subClassOf soreag:GeologicallySignificantSite ;
+                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                dcterms:source [ ] ,
+[ ] ;
+skos:definition "Geotrails aim to provide a tourism experience linking an area’s geology and landscape (i.e., its geological heritage features, including mining heritage) to its biodiversity and cultural history. (Geological Society of Australia)"@en ;
+skos:prefLabel "geotrail"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GiantDikeSwarm
 soreag:GiantDikeSwarm rdf:type owl:Class ;
-                    rdfs:subClassOf soreag:Dike ;
-                    rdfs:label "giant dike swarm"@en .
+                      rdfs:subClassOf soreag:Dike ;
+                      rdfs:label "giant dike swarm"@en .
+
+
+###  http://sweetontology.net/realmGeol/Graben
+soreag:Graben rdf:type owl:Class ;
+              rdfs:subClassOf soreag:StructuralFeature ;
+              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+              dcterms:source <http://www.glossaryofgeology.org> ;
+              skos:definition "An elongate trough or basin, bounded on both sides by high-angle normal faults that dip toward one another. It is a structural form that may or may not be geomorphologically expressed as a rift valley. (Neuendorf et al., 2011)"@en ;
+              skos:prefLabel "graben"@en .
+
+
+###  http://sweetontology.net/realmGeol/Group
+soreag:Group rdf:type owl:Class ;
+             rdfs:subClassOf soreag:LithostratigraphicUnit ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+             skos:definition "A succession of two or more contiguous or associated formations with significant and diagnostic lithologic properties in common. (ICS, Online, December 2019)"@en ;
+             skos:prefLabel "group"@en .
 
 
 ###  http://sweetontology.net/realmGeol/GuttenburgDiscontinuity
 soreag:GuttenburgDiscontinuity rdf:type owl:Class ;
-                             rdfs:subClassOf soreag:GeologicBoundary ;
-                             rdfs:label "guttenburg discontinuity"@en .
+                               rdfs:subClassOf soreag:GeologicBoundary ;
+                               rdfs:label "guttenburg discontinuity"@en .
+
+
+###  http://sweetontology.net/realmGeol/HalfGraben
+soreag:HalfGraben rdf:type owl:Class ;
+                  rdfs:subClassOf soreag:StructuralFeature ;
+                  dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                  dcterms:source <http://www.glossaryofgeology.org> ;
+                  skos:definition "An elongate, asymmetric trough or basin bounded on one side by a normal fault. (Neuendorf et al., 2011)"@en ;
+                  skos:prefLabel "half graben"@en .
+
+
+###  http://sweetontology.net/realmGeol/Horst
+soreag:Horst rdf:type owl:Class ;
+             rdfs:subClassOf soreag:StructuralFeature ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <http://www.glossaryofgeology.org> ;
+             skos:definition "An elongate block that is bounded on both sides by normal faults that dip away from one another. It is a structural form and may or may not be expressed geomorphologically. (Neuendorf et al., 2011)"@en ;
+             skos:prefLabel "horst"@en .
+
+
+###  http://sweetontology.net/realmGeol/IgneousProvince
+soreag:IgneousProvince rdf:type owl:Class ;
+                       rdfs:subClassOf soreag:GeologicProvince ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       dcterms:source <http://www.glossaryofgeology.org> ;
+                       skos:altLabel "Petrographic province"@en ;
+                       skos:definition "A broad area in which similar igneous rocks are considered to have been formed during the same period of (igneous) activity. (Neuendorf et al., 2011)"@en ;
+                       skos:prefLabel "igneous province"@en .
+
+
+###  http://sweetontology.net/realmGeol/Inlier
+soreag:Inlier rdf:type owl:Class ;
+              rdfs:subClassOf soreag:DenudationalFeature ;
+              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+              dcterms:source <http://www.glossaryofgeology.org> ;
+              skos:definition "An area or group of rocks surrounded by younger rocks, e.g., an eroded anticlinal crest. (Neuendorf et al., 2011)"@en ;
+              skos:prefLabel "inlier"@en .
 
 
 ###  http://sweetontology.net/realmGeol/InnerCore
 soreag:InnerCore rdf:type owl:Class ;
-               rdfs:subClassOf soreag:Mantle ;
-               owl:disjointWith soreag:OuterCore ;
-               rdfs:label "inner core"@en .
+                 rdfs:subClassOf soreag:Mantle ;
+                 owl:disjointWith soreag:OuterCore ;
+                 rdfs:label "inner core"@en .
+
+
+###  http://sweetontology.net/realmGeol/IntervalZone
+soreag:IntervalZone rdf:type owl:Class ;
+                    rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                    dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                    dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                    skos:definition "The body of fossiliferous strata between two specified biohorizons. (ICS, Online, December 2019)"@en ;
+                    skos:prefLabel "interval zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Klippe
+soreag:Klippe rdf:type owl:Class ;
+              rdfs:subClassOf soreag:DenudationalFeature ;
+              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+              dcterms:source <http://www.glossaryofgeology.org> ;
+              skos:altLabel "thrust outlier"@en ;
+              skos:definition "An isolated rock unit that is an erosional remnant or outlier of a nappe. Plural: klippen. (Neuendorf et al., 2011)"@en ;
+              skos:prefLabel "klippe"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Laccolith
 soreag:Laccolith rdf:type owl:Class ;
-               rdfs:subClassOf soreag:PlutonicStructure ;
-               rdfs:label "laccolith"@en .
+                 rdfs:subClassOf soreag:PlutonicStructure ;
+                 rdfs:label "laccolith"@en .
+
+
+###  http://sweetontology.net/realmGeol/LargeIgneousProvince
+soreag:LargeIgneousProvince rdf:type owl:Class ;
+                            rdfs:subClassOf soreag:GeologicProvince ;
+                            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                            dcterms:source <http://www.glossaryofgeology.org> ;
+                            skos:definition " A region characterized by massive crustal emplacements of predominantly mafic (Mg- and Fe-rich) extrusive and intrusive rocks which originated through processes other than \"normal\" seafloor spreading (Coffin & Eldholm, 1994); includes continental flood basalt provinces (e.g., Deccan Traps), oceanic plateaus (e.g., Ontong & Java Oceanic Plateaus), and North Atlantic volcanic passive margins. Abbrev: LIP. (Neuendorf et al., 2011)"@en ;
+                            skos:prefLabel "large igneous province"@en .
 
 
 ###  http://sweetontology.net/realmGeol/LehmannDiscontinuity
 soreag:LehmannDiscontinuity rdf:type owl:Class ;
-                          rdfs:subClassOf soreag:GeologicBoundary ;
-                          rdfs:label "lehmann discontinuity"@en .
+                            rdfs:subClassOf soreag:GeologicBoundary ;
+                            rdfs:label "lehmann discontinuity"@en .
+
+
+###  http://sweetontology.net/realmGeol/LineageZone
+soreag:LineageZone rdf:type owl:Class ;
+                   rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                   dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                   dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                   skos:definition "The body of strata containing specimens representing a specific segment of an evolutionary lineage. (ICS, Online, December 2019)"@en ;
+                   skos:prefLabel "lineage zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Lithodeme
+soreag:Lithodeme rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:LithodemicFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                 skos:definition "A lithodeme is the fundamental formal unit in lithodemic classification and corresponds to formation in lithostratigraphy. A lithodeme may consist of a single rock type, several rock types (if they form a lithologically coherent unit) or several rock types that have become tectonically intermingled to form a lithological unit. A lithodeme may contain informal sub-lithodemes, some of which may be named phase or zone (e.g., mineralized zone, pegmatitic zone). The term complex can be used for a non-ranked lithodemic unit. (Kumpulainen, 2017)"@en ;
+                 skos:prefLabel "lithodeme"@en .
+
+
+###  http://sweetontology.net/realmGeol/LithodemicFeature
+soreag:LithodemicFeature rdf:type owl:Class ;
+                         rdfs:subClassOf soreag:GeologicFeature ;
+                         owl:disjointWith soreag:StratigraphicFeature ;
+                         dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                         dcterms:source <https://doi.org/10.1306/05230505015> ;
+                         skos:definition "A Lithodemic Unit is a defined body of predominantly intrusive, highly metamorphosed, or intensely deformed rock that, because it is intrusive or has lost primary structure through metamorphism or tectonism, generally does not conform to the Law of Superposition. Expressions of age of lithodemic units (because they are non-stratigraphic) should be given in terms of the appropriate geochronologic (geological-time) unit, and thus not by chronstratigraphic (time-rock) terms. (North American Stratigraphic Code, 2005)"@en ;
+                         skos:prefLabel "lithodemic feature"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Lithosphere
 soreag:Lithosphere rdf:type owl:Class ;
-                 rdfs:subClassOf soreag:GeosphereLayer ,
-                                 [ rdf:type owl:Restriction ;
-                                   owl:onProperty sorelsc:containsMaterial ;
-                                   owl:allValuesFrom somarock:Rock
-                                 ] ;
-                 rdfs:label "lithosphere"@en .
+                   rdfs:subClassOf soreag:GeosphereLayer ,
+                                   [ rdf:type owl:Restriction ;
+                                     owl:onProperty sorelsc:containsMaterial ;
+                                     owl:allValuesFrom somarock:Rock
+                                   ] ;
+                   rdfs:label "lithosphere"@en .
+
+
+###  http://sweetontology.net/realmGeol/LithostratigraphicUnit
+soreag:LithostratigraphicUnit rdf:type owl:Class ;
+                              rdfs:subClassOf soreag:StratigraphicUnit ;
+                              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                              dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                              skos:definition "Lithostratigraphic units are bodies of rocks, bedded or unbedded, that are defined and characterized on the basis of their lithologic properties and their stratigraphic relations. Lithostratigraphic units are the basic units of geologic mapping. (ICS, Online, December 2019)"@en ;
+                              skos:prefLabel "lithostratigraphic unit"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Lopolith
 soreag:Lopolith rdf:type owl:Class ;
-              rdfs:subClassOf soreag:PlutonicStructure ;
-              rdfs:label "lopolith"@en .
+                rdfs:subClassOf soreag:PlutonicStructure ;
+                rdfs:label "lopolith"@en .
 
 
 ###  http://sweetontology.net/realmGeol/LowerMantle
 soreag:LowerMantle rdf:type owl:Class ;
-                 rdfs:subClassOf soreag:Mantle ;
-                 rdfs:label "lower mantle"@en .
+                   rdfs:subClassOf soreag:Mantle ;
+                   rdfs:label "lower mantle"@en .
+
+
+###  http://sweetontology.net/realmGeol/MagnetostratigraphicPolaritySubzone
+soreag:MagnetostratigraphicPolaritySubzone rdf:type owl:Class ;
+                                           rdfs:subClassOf soreag:MagnetostratigraphicUnit ;
+                                           dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                           dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                                          <https://doi.org/10.1130/9780813774022> ;
+                                           skos:definition "Polarity Zones may be subdivided into Polarity Suzones. The corresponding interval of geological time during which the rocks in the Polarity Subzone were deposited is referred to as its associated Polarity Subchron. (Salvador, 2013; ICS, Online, December, 2019)"@en ;
+                                           skos:prefLabel "magnetostratigraphic polarity subzone"@en .
+
+
+###  http://sweetontology.net/realmGeol/MagnetostratigraphicPolaritySuperzone
+soreag:MagnetostratigraphicPolaritySuperzone rdf:type owl:Class ;
+                                             rdfs:subClassOf soreag:MagnetostratigraphicUnit ;
+                                             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                             dcterms:source <http://pid.geoscience.gov.au/dataset/ga/70149> ,
+                                                            <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                                            <https://doi.org/10.1130/9780813774022> ;
+                                             skos:definition "Polarity Zones may be grouped into Polarity Superzones (Hyperzones in Russian literature). The corresponding interval of geological time during which the rocks in the Polarity Superzone were deposited is referred to as its associated Polarity Superchron. As an example of the latter, the mid-Carboniferous – Middle Permian Kiaman Superchron is the longest known period of predominantly reversed polarity, which was terminated by the Illawarra Geomagnetic Polarity Reversal near the base of the Capitanian. (Salvador, 2013; ICS, Online, December, 2019; Gradstein et al., 2012)"@en ;
+                                             skos:prefLabel "magnetostratigraphic polarity superzone"@en .
+
+
+###  http://sweetontology.net/realmGeol/MagnetostratigraphicPolarityZone
+soreag:MagnetostratigraphicPolarityZone rdf:type owl:Class ;
+                                        rdfs:subClassOf soreag:MagnetostratigraphicUnit ;
+                                        dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                        dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                                       <https://doi.org/10.1130/9780813774022> ;
+                                        skos:definition "The basic formal unit in magnetostratigraphic polarity classification is the Magnetostratigraphic Polarity Zone (or Polarity Zone). The corresponding interval of geological time during which the rocks in the Polarity Zone were deposited is referred to as its associated Polarity Chron. (Salvador, 2013; ICS, Online, December, 2019)"@en ;
+                                        skos:prefLabel "magnetostratigraphic polarity zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/MagnetostratigraphicUnit
+soreag:MagnetostratigraphicUnit rdf:type owl:Class ;
+                                rdfs:subClassOf soreag:StratigraphicUnit ;
+                                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                               <https://doi.org/10.1130/9780813774022> ;
+                                skos:definition "A Magnetostratigraphic Unit (Magnetozone) is a body of rocks unified by similar magnetic characteristics which allow it to be differentiated from adjacent rock bodies.  The term is collectively applied to the different kinds of stratigraphic units that are identified by their measurable magnetic properties. (Salvador, 2013; ICS, Online, December, 2019)"@en ;
+                                skos:prefLabel "magnetostratigraphic unit"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Mantle
 soreag:Mantle rdf:type owl:Class ;
-            rdfs:subClassOf soreag:GeosphereLayer ,
-                            [ rdf:type owl:Restriction ;
-                              owl:onProperty sorelsp:hasUpperBoundary ;
-                              owl:allValuesFrom soreag:Moho
-                            ] ;
-            rdfs:label "mantle"@en .
+              rdfs:subClassOf soreag:GeosphereLayer ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty sorelsp:hasUpperBoundary ;
+                                owl:allValuesFrom soreag:Moho
+                              ] ;
+              rdfs:label "mantle"@en .
+
+
+###  http://sweetontology.net/realmGeol/Member
+soreag:Member rdf:type owl:Class ;
+              rdfs:subClassOf soreag:LithostratigraphicUnit ;
+              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+              dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+              skos:definition "The formal lithostratigraphic unit next in rank below a formation. (ICS, Online, December 2019)"@en ;
+              skos:prefLabel "member"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Mesosphere
 soreag:Mesosphere rdf:type owl:Class ;
-                owl:equivalentClass soreag:UpperMantleRigid ;
-                rdfs:label "mesosphere"@en .
+                  owl:equivalentClass soreag:UpperMantleRigid ;
+                  rdfs:subClassOf soreag:UpperMantle ;
+                  rdfs:label "mesosphere"@en .
+
+
+###  http://sweetontology.net/realmGeol/MineralProvince
+soreag:MineralProvince rdf:type owl:Class ;
+                       rdfs:subClassOf soreag:GeologicProvince ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       dcterms:source <http://www.glossaryofgeology.org> ;
+                       skos:altLabel "Metallogenic province"@en ;
+                       skos:definition "An area characterized by a particular assemblage of mineral deposits, or by one or more characteristic types of mineralization. A metallogenic province may have had more than one episode of mineralization.  (Neuendorf et al., 2011)"@en ;
+                       skos:prefLabel "mineral province"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Moho
 soreag:Moho rdf:type owl:Class ;
-          owl:equivalentClass soreag:Mohorovi_i_Discontinuity ;
-          rdfs:subClassOf soreag:GeologicBoundary ;
-          rdfs:label "moho"@en .
+            owl:equivalentClass soreag:Mohorovi_i_Discontinuity ;
+            rdfs:subClassOf soreag:GeologicBoundary ;
+            rdfs:label "moho"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Mohorovi_i_Discontinuity
 soreag:Mohorovi_i_Discontinuity rdf:type owl:Class ;
-                              rdfs:label "mohorovicic discontinuity"@en .
+                                rdfs:subClassOf soreag:GeologicBoundary ;
+                                rdfs:label "mohorovicic discontinuity"@en .
+
+
+###  http://sweetontology.net/realmGeol/Monocline
+soreag:Monocline rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:StructuralFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                 skos:definition "A one-limbed flexure on either side of which the strata are horizontal or dip uniformly at low angles. (Allaby, 2013)"@en ;
+                 skos:prefLabel "monocline"@en .
+
+
+###  http://sweetontology.net/realmGeol/MyloniteZone
+soreag:MyloniteZone rdf:type owl:Class ;
+                    rdfs:subClassOf soreag:StructuralFeature ;
+                    dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                    dcterms:source <http://www.glossaryofgeology.org> ,
+                                   <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                    skos:definition "Usually found in narrow, planar zones of localised ductile deformation, although kilometre-scale zones exist. Mylonites form in shear zones by mechanical grinding, crushing and recrystallization of rock to produce a metamorphic rock that has foliation and is much finer grained than its precursor. (Modified from: Neuendorf et al., 2011; Allaby, 2013)"@en ;
+                    skos:prefLabel "mylonite zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Nappe
+soreag:Nappe rdf:type owl:Class ;
+             rdfs:subClassOf soreag:TechtonostratigraphicEntity ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <http://www.glossaryofgeology.org> ,
+                            <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+             skos:definition "A sheetlike, allochthonous rock unit, which has moved on a predominantly horizontal surface as a result of thrust faulting, recumbent folding, or both.  Fold limbs and axes are approximately horizontal (After Neuendorf et al., 2011; Allaby, 2013)"@en ;
+             skos:prefLabel "nappe"@en .
+
+
+###  http://sweetontology.net/realmGeol/NappeComplex
+soreag:NappeComplex rdf:type owl:Class ;
+                    rdfs:subClassOf soreag:TechtonostratigraphicEntity ;
+                    dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                    dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                    skos:definition "A nappe complex consists of two or more distinct nappes that are stacked upon, and related to, one another in some significant respect, e.g., shared general environment of origin, similar metamorphism and/or deformation. (Kumpulainen, 2017)"@en ;
+                    skos:prefLabel "nappe complex"@en .
 
 
 ###  http://sweetontology.net/realmGeol/OuterCore
 soreag:OuterCore rdf:type owl:Class ;
-               rdfs:subClassOf soreag:Mantle ;
-               rdfs:label "outer core"@en .
+                 rdfs:subClassOf soreag:Mantle ;
+                 rdfs:label "outer core"@en .
+
+
+###  http://sweetontology.net/realmGeol/Outlier
+soreag:Outlier rdf:type owl:Class ;
+               rdfs:subClassOf soreag:DenudationalFeature ;
+               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+               dcterms:source <http://www.glossaryofgeology.org> ;
+               skos:definition " An area or group of rocks surrounded by older rocks. (Neuendorf et al., 2011)"@en ;
+               skos:prefLabel "outlier"@en .
+
+
+###  http://sweetontology.net/realmGeol/OverturnedFold
+soreag:OverturnedFold rdf:type owl:Class ;
+                      rdfs:subClassOf soreag:StructuralFeature ;
+                      dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                      dcterms:source <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                      skos:altLabel "Overfold"@en ,
+                                    "Overfolded Zone"@en ;
+                      skos:definition "A zone where folds in their axial planes are inclined so that the fold limbs dip in the same direction, although not necessarily by the same amount. For each fold, one limb is thus ‘overturned'. (Allaby, 2008)"@en ;
+                      skos:prefLabel "overturned fold"@en .
+
+
+###  http://sweetontology.net/realmGeol/PedostratigraphicUnit
+soreag:PedostratigraphicUnit rdf:type owl:Class ;
+                             rdfs:subClassOf soreag:StratigraphicUnit ;
+                             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                             dcterms:source <http://www.glossaryofgeology.org> ,
+                                            <https://doi.org/10.1306/05230505015> ;
+                             skos:definition "A buried, traceable, three-dimensional body of rock (or sediment) that consists of one or more differentiated pedologic horizons developed in, and overlain by, one or more formally defined lithostratigraphic or allostratigraphic units. (NACSN, 2005; Neuendorf et al., 2011)"@en ;
+                             skos:prefLabel "pedostratigraphic unit"@en .
+
+
+###  http://sweetontology.net/realmGeol/Peneplain
+soreag:Peneplain rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:DenudationalFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.glossaryofgeology.org> ,
+                                <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                 skos:definition "A low, nearly featureless, gently undulating land surface of considerable area, which has been produced by the processes of prolonged subaerial erosion almost to base level; it is the end product of a cycle of erosion. (Davis, 1889; Neuendorf et al., 2011; Allaby, 2013)"@en ;
+                 skos:prefLabel "peneplain"@en .
+
+
+###  http://sweetontology.net/realmGeol/Plate
+soreag:Plate rdf:type owl:Class ;
+             rdfs:subClassOf soreag:TectonicEntity ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <http://www.glossaryofgeology.org> ,
+                            <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+             skos:altLabel "Tectonic Plate"@en ;
+             skos:definition "The lithosphere is divided into a number of discrete tectonic plates each of which has motion relative to other plates. (e.g., Neuendorf et al., 2011; Allaby, 2013)"@en ;
+             skos:prefLabel "plate"@en .
 
 
 ###  http://sweetontology.net/realmGeol/PlutonicStructure
 soreag:PlutonicStructure rdf:type owl:Class ;
-                       rdfs:subClassOf soreag:GeologicStructure ;
-                       rdfs:label "plutonic structure"@en .
+                         rdfs:subClassOf soreag:GeologicStructure ;
+                         rdfs:label "plutonic structure"@en .
 
 
-###  http://sweetontology.net/realmGeol/SeismicZone
-soreag:SeismicZone rdf:type owl:Class ;
-                 rdfs:subClassOf soreag:GeologicFeature ;
-                 rdfs:label "seismic zone"@en .
+###  http://sweetontology.net/realmGeol/RangeZone
+soreag:RangeZone rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                 skos:definition "The body of strata representing the known stratigraphic and geographic range of occurrence of a particular taxon or combination of two taxa of any rank. There are two principal types: taxon-range zones and concurrent-range zones. (ICS, Online, December 2019)"@en ;
+                 skos:prefLabel "range zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/Ridge
+soreag:Ridge rdf:type owl:Class ;
+             rdfs:subClassOf soreag:StructuralFeature ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <https://en.wikipedia.org/wiki/Ridge> ;
+             skos:definition "A ridge or a mountain ridge is a geographical feature consisting of a chain of mountains or hills that form a continuous elevated crest for some distance. The sides of the ridge slope away from narrow top on either side. The lines along the crest formed by the highest points, with the terrain dropping down on either sides, are called the ridgelines. Ridges are usually termed hills or mountains as well, depending on size. (Adapted from Wikipedia)"@en ;
+             skos:prefLabel "ridge"@en .
+
+
+###  http://sweetontology.net/realmGeol/SeismicProvince
+soreag:SeismicProvince rdf:type owl:Class ;
+                       rdfs:subClassOf soreag:GeophysicalDomain ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       dcterms:source <http://pid.geoscience.gov.au/dataset/ga/70149> ,
+                                      <https://doi.org/10.1016/j.tecto.2012.02.022> ;
+                       skos:altLabel "seismic zone"@en ;
+                       skos:definition "Representative of a discrete \"volume\" of middle to lower crust which cannot be traced to the surface, and whose crustal reflectivity is different to that of laterally or vertically adjoining provinces (in differing lithology, geological history, and/or structural architecture). A Seismic Province it is a Geophysical Domain. In North Queensland, the Numil and Abingdon Seismic Provinces are two lower crustal sectors that have been interpreted to represent microcontinents that accreted to the eastern fringe of the North Australian Craton prior to the late Paleoproterozoic (Korsch et al., 2010, Korsch, 2012)"@en ;
+                       skos:prefLabel "seismic province"@en .
+
+
+###  http://sweetontology.net/realmGeol/SequenceStratigraphicUnit
+soreag:SequenceStratigraphicUnit rdf:type owl:Class ;
+                                 rdfs:subClassOf soreag:StratigraphicUnit ;
+                                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                 dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ,
+                                                <https://doi.org/10.1127/0078-0421/2011/0011> ;
+                                 skos:definition "A Sequence Stratigraphic Unit is an extensive, depositional unit that may be bounded by subaerial unconformities and their correlative conformities, by transgressive surfaces or by surfaces of maximum marine flooding. It documents changes in relative sea level, which may have been the result of eustasy, regional or local tectonic movements, compaction, isostasy or the combination of two or more of these factors. (Kumpulainen, 2017; Catuneanu et al., 2011)"@en ;
+                                 skos:prefLabel "sequence stratigraphic unit"@en .
+
+
+###  http://sweetontology.net/realmGeol/ShearZone
+soreag:ShearZone rdf:type owl:Class ;
+                 rdfs:subClassOf soreag:StructuralFeature ;
+                 dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                 dcterms:source <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                 skos:definition "A region, narrow compared to its length, within which rocks have undergone intense deformation: viz. brecciation. There are two end-members: brittle shear zones (faults), marked by a surface of rupture, which are a common feature of higher crustal levels; and ductile shear zones in which deformation is continuous and characterized by high ductile strain due to the rocks having formed under high temperatures and pressures at deeper crustal levels. Both brittle and ductile shear zones may occur as subparallel or conjugate sets. (after Allaby, 2013 (Oxford Dictionary of Geology and Earth Sciences))"@en ;
+                 skos:prefLabel "shear zone"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Sill
 soreag:Sill rdf:type owl:Class ;
-          rdfs:subClassOf soreag:PlutonicStructure ;
-          rdfs:label "sill"@en .
+            rdfs:subClassOf soreag:PlutonicStructure ;
+            rdfs:label "sill"@en .
 
 
 ###  http://sweetontology.net/realmGeol/SkinLayer
 soreag:SkinLayer rdf:type owl:Class ;
-               rdfs:label "skin layer"@en .
+                 rdfs:subClassOf soreag:GeosphereLayer ;
+                 rdfs:label "skin layer"@en .
 
 
-###  http://sweetontology.net/realmGeol/SolidEarth
-soreag:SolidEarth rdf:type owl:Class ;
-                rdfs:label "solid earth"@en .
+###  http://sweetontology.net/realmGeol/StratigraphicEvent
+soreag:StratigraphicEvent rdf:type owl:Class ;
+                          rdfs:subClassOf soreag:StratigraphicFeature ;
+                          dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                          dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                          skos:definition "Stratigraphic Events reflect physical, chemical and biological events that left identifiable, widespread, if not worldwide, traces or markers in the sedimentary or extrusive igneous record (Kumpulainen, 2017)"@en ;
+                          skos:prefLabel "stratigraphic event"@en .
+
+
+###  http://sweetontology.net/realmGeol/StratigraphicFeature
+soreag:StratigraphicFeature rdf:type owl:Class ;
+                            rdfs:subClassOf soreag:GeologicFeature ;
+                            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                            dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                           <https://doi.org/10.1080/11035897.2016.1178666> ;
+                            skos:definition "Stratigraphic Features embrace Stratigraphic Units, which are units of rock and/or sediment that conform to the Law of Superposition (e.g. lithostratigraphic units, biostratigraphic units, chronostratigraphic units), and Stratigraphic Events which reflect physical, chemical and biological events that left identifiable, widespread, if not worldwide, traces or markers in the sedimentary or extrusive igneous record (ICS; Kumpulainen, R.A., 2016)"@en ;
+                            skos:prefLabel "stratigraphic feature"@en .
+
+
+###  http://sweetontology.net/realmGeol/StratigraphicUnit
+soreag:StratigraphicUnit rdf:type owl:Class ;
+                         rdfs:subClassOf soreag:StratigraphicFeature ;
+                         dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                         dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ,
+                                        <https://doi.org/10.1130/9780813774022> ;
+                         skos:definition "Stratigraphic Units are units of rock and/or sediment that conform to the Law of Superposition (e.g., lithostratigraphic units, biostratigraphic units, chronostratigraphic units). (Murphy & Salvador, 2000; ICS, Online, December, 2019)"@en ;
+                         skos:prefLabel "stratigraphic unit"@en .
+
+
+###  http://sweetontology.net/realmGeol/StructuralFeature
+soreag:StructuralFeature rdf:type owl:Class ;
+                         rdfs:subClassOf soreag:GeologicFeature ;
+                         dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                         dcterms:source <http://www.glossaryofgeology.org> ;
+                         skos:definition "A feature produced by deformation or displacement of rocks, such as a fold or fault. (Neuendorf et al., 2011)"@en ;
+                         skos:prefLabel "structural feature"@en .
+
+
+###  http://sweetontology.net/realmGeol/Subgroup
+soreag:Subgroup rdf:type owl:Class ;
+                rdfs:subClassOf soreag:LithostratigraphicUnit ;
+                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                skos:definition "A Subgroup is a part of a Group. (Definition created here: Paul Blake, John McKellar)"@en ;
+                skos:prefLabel "subgroup"@en .
 
 
 ###  http://sweetontology.net/realmGeol/Subsurface
 soreag:Subsurface rdf:type owl:Class ;
-                rdfs:subClassOf sorea:PlanetaryRealm ;
-                rdfs:label "subsurface"@en .
+                  rdfs:subClassOf sorea:PlanetaryRealm ;
+                  rdfs:label "subsurface"@en .
+
+
+###  http://sweetontology.net/realmGeol/Suite
+soreag:Suite rdf:type owl:Class ;
+             rdfs:subClassOf soreag:LithodemicFeature ;
+             dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+             dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+             skos:definition "A Suite consists of two or more lithodemes that are genetically associated and have a common geological history. The individual lithodemes need not have identical (crystallization or depositional) ages but they should have similar ages and belong, for example, to the same phase of an orogeny. Also, they must be of the same lithological class, either intrusive or metamorphic. Two or more suites may form a Supersuite. (Kumpulainen, 2017)"@en ;
+             skos:prefLabel "suite"@en .
+
+
+###  http://sweetontology.net/realmGeol/Supercontinent
+soreag:Supercontinent rdf:type owl:Class ;
+                      rdfs:subClassOf soreag:TectonicEntity ;
+                      dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                      dcterms:source <http://doi.org/10.22459/SN.08.2012> ;
+                      skos:definition "A large continent formed by the amalgamation of most or all of Earth’s continental landmasses. (Blewett, 2012)"@en ;
+                      skos:prefLabel "supercontinent"@en .
+
+
+###  http://sweetontology.net/realmGeol/Supergroup
+soreag:Supergroup rdf:type owl:Class ;
+                  rdfs:subClassOf soreag:LithostratigraphicUnit ;
+                  dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                  dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                  skos:definition "A lithostratigraphic Supergroup may contain several associated groups or associated groups and formations, all with significant lithologic properties in common. (ICS, Online, December 2019)"@en ;
+                  skos:prefLabel "supergroup"@en .
+
+
+###  http://sweetontology.net/realmGeol/Supersuite
+soreag:Supersuite rdf:type owl:Class ;
+                  rdfs:subClassOf soreag:LithodemicFeature ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty sorel:hasPart ;
+                                    owl:allValuesFrom soreag:Suite
+                                  ] ;
+                  dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                  dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                  skos:definition "A supersuite is composed of two or more suites that are genetically associated, i.e., belong to the same class, and have at least partly a common geological history, e.g., the same orogenic phase. A supersuite is defined according to its lithodemic members and may be named after a type area, its geographical distribution and/or its lithological properties. (Kumpulainen, 2017)"@en ;
+                  skos:prefLabel "supersuite"@en .
+
+
+###  http://sweetontology.net/realmGeol/Syncline
+soreag:Syncline rdf:type owl:Class ;
+                rdfs:subClassOf soreag:StructuralFeature ;
+                dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                dcterms:source <http://www.glossaryofgeology.org> ;
+                skos:definition "A fold of which the core contains the stratigraphically younger rocks; it is generally concave upward. (Neuendorf et al., 2011)"@en ;
+                skos:prefLabel "syncline"@en .
+
+
+###  http://sweetontology.net/realmGeol/Synclinorium
+soreag:Synclinorium rdf:type owl:Class ;
+                    rdfs:subClassOf soreag:StructuralFeature ;
+                    dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                    dcterms:source <http://www.glossaryofgeology.org> ;
+                    skos:definition "A composite synclinal structure of regional extent composed of lesser folds. (Neuendorf et al., 2011)"@en ;
+                    skos:prefLabel "synclinorium"@en .
+
+
+###  http://sweetontology.net/realmGeol/Synform
+soreag:Synform rdf:type owl:Class ;
+               rdfs:subClassOf soreag:StructuralFeature ;
+               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+               dcterms:source <http://www.glossaryofgeology.org> ;
+               skos:definition "Any fold whose limbs close at the bottom. The term is usually used when the folded layers do not possess a stratigraphic order, when the stratigraphic order of the folded layers is not known, or when the fold core also contains the stratigraphically older rock. (Neuendorf et al., 2011)"@en ;
+               skos:prefLabel "synform"@en .
+
+
+###  http://sweetontology.net/realmGeol/TaxonRangeZone
+soreag:TaxonRangeZone rdf:type owl:Class ;
+                      rdfs:subClassOf soreag:BiostratigraphicUnit ;
+                      dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                      dcterms:source <http://www.stratigraphy.org/index.php/ics-stratigraphicguide> ;
+                      skos:definition "The body of strata representing the known range of stratigraphic and geographic occurrence of specimens of a particular taxon. (ICS, Online, December 2019)"@en ;
+                      skos:prefLabel "taxon range zone"@en .
+
+
+###  http://sweetontology.net/realmGeol/TechtonostratigraphicEntity
+soreag:TechtonostratigraphicEntity rdf:type owl:Class ;
+                                   rdfs:subClassOf soreag:TectonicFeature ;
+                                   dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                   dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                                   skos:definition "Tectonostratigraphic Entities/Units, separately distinguished from Tectonic Entities/Units (following Kumpulainen, 2017), encompass generally flat-lying, scale-independent, tectonic units that are bounded by zones of high strain (ductile shear zone, deformation zone or belt, fault, fault zone, etc.). They include tectonically-displaced allochthonous sheets that are represented by nappes (thrust sheets) and nappe complexes, as well as accreted terranes"@en ;
+                                   skos:prefLabel "techtonostratigraphic entity"@en .
+
+
+###  http://sweetontology.net/realmGeol/TectonicEntity
+soreag:TectonicEntity rdf:type owl:Class ;
+                      rdfs:subClassOf soreag:TectonicFeature ;
+                      dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                      dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                      skos:definition "Tectonic Entitities include continents, supercontinents, tectonic plates, and intraplate tectonic features (provinces), such as cratons/shields (in the continental realm), orogens, sedimentary basins, and tectonised/metamorphosed and/or mineralised regions, as well as large igneous provinces (LIPs). (Modified from Kumpulainen, 2017)"@en ;
+                      skos:prefLabel "techtonic entity"@en .
+
+
+###  http://sweetontology.net/realmGeol/TectonicFeature
+soreag:TectonicFeature rdf:type owl:Class ;
+                       rdfs:subClassOf soreag:GeologicFeature ;
+                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                       dcterms:source <https://doi.org/10.1080/11035897.2016.1178666> ;
+                       skos:definition "Tectonic Features include Tectonic Entities and Tectonostratigraphic Entities. The former encompass Geological Provinces (e.g., cratons/shields, orogens, sedimentary basins, igneous/petrographic provinces, etc.), and the latter, tectonostratigraphic units, such as nappes and terranes. (Modified from Kumpulainen, 2017). Collectively, they constitute continents, past and present, and, when previously formed, supercontinents"@en ;
+                       skos:prefLabel "techtonic feature"@en .
+
+
+###  http://sweetontology.net/realmGeol/TectonisedMetomorphosedProvince
+soreag:TectonisedMetomorphosedProvince rdf:type owl:Class ;
+                                       rdfs:subClassOf soreag:GeologicProvince ;
+                                       dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                                       skos:definition "A Tectonised and/or Metamorphosed Province is generally an old sedimentary basin that has been strongly tectonised and/or metamorphosed, so that its original basin extent and form are no longer preserved. Such provinces may have associated magmatism and metallogenesis. (Definition created here)"@en ;
+                                       skos:prefLabel "tectonised metomorphosed province"@en .
+
+
+###  http://sweetontology.net/realmGeol/Terrane
+soreag:Terrane rdf:type owl:Class ;
+               rdfs:subClassOf soreag:TechtonostratigraphicEntity ;
+               dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+               dcterms:source <http://www.glossaryofgeology.org> ;
+               skos:definition "A fault-bounded body of rock of regional extent, characterised by a geologic history different from that of contiguous terranes or bounding continents. A terrane is generally considered to be a discrete allochthonous fragment of oceanic or continental material added to a craton (or continental plate) at an active margin by accretion. (After  Neuendorf et al., 2011)"@en ;
+               skos:prefLabel "terrane"@en .
 
 
 ###  http://sweetontology.net/realmGeol/TransitionalCrust
 soreag:TransitionalCrust rdf:type owl:Class ;
-                       rdfs:subClassOf soreag:Crust ;
-                       rdfs:label "transitional crust"@en .
+                         rdfs:subClassOf soreag:Crust ;
+                         rdfs:label "transitional crust"@en .
 
 
 ###  http://sweetontology.net/realmGeol/TransitionalLithosphere
 soreag:TransitionalLithosphere rdf:type owl:Class ;
-                             rdfs:subClassOf soreag:GeosphereLayer ,
-                                             [ rdf:type owl:Restriction ;
-                                               owl:onProperty sorelph:hasPlanetaryStructure ;
-                                               owl:someValuesFrom soreag:TransitionalCrust
-                                             ] ;
-                             rdfs:label "transitional lithosphere"@en .
+                               rdfs:subClassOf soreag:GeosphereLayer ,
+                                               [ rdf:type owl:Restriction ;
+                                                 owl:onProperty sorelph:hasPlanetaryStructure ;
+                                                 owl:someValuesFrom soreag:TransitionalCrust
+                                               ] ;
+                               rdfs:label "transitional lithosphere"@en .
+
+
+###  http://sweetontology.net/realmGeol/Unconformity
+soreag:Unconformity rdf:type owl:Class ;
+                    rdfs:subClassOf soreag:DenudationalFeature ;
+                    dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                    dcterms:source <http://www.glossaryofgeology.org> ,
+                                   <https://doi.org/10.1093/acref/9780199653065.001.0001> ;
+                    skos:definition "The surface of contact between rock strata that represents a lack of continuity in deposition, encompassing a period of nondeposition or weathering/erosion prior to the deposition of younger rocks, sometimes, in the case of sedimentary rocks, marked by the absence of conformity between the dip and strike of underlying and overlying strata. (Modified from Neuendorf et al., 2011; Allaby, 2013)"@en ;
+                    skos:prefLabel "unconformity"@en .
 
 
 ###  http://sweetontology.net/realmGeol/UpperMantle
 soreag:UpperMantle rdf:type owl:Class ;
-                 rdfs:subClassOf soreag:Mantle ;
-                 rdfs:label "upper mantle"@en .
+                   rdfs:subClassOf soreag:Mantle ;
+                   rdfs:label "upper mantle"@en .
 
 
 ###  http://sweetontology.net/realmGeol/UpperMantleFlowing
 soreag:UpperMantleFlowing rdf:type owl:Class ;
-                        rdfs:label "upper mantle flowing"@en .
+                          rdfs:subClassOf soreag:UpperMantle ;
+                          rdfs:label "upper mantle flowing"@en .
 
 
 ###  http://sweetontology.net/realmGeol/UpperMantleRigid
 soreag:UpperMantleRigid rdf:type owl:Class ;
-                      rdfs:subClassOf soreag:UpperMantle ;
-                      rdfs:label "upper mantle rigid"@en .
+                        rdfs:subClassOf soreag:UpperMantle ;
+                        rdfs:label "upper mantle rigid"@en .
+
+
+###  http://sweetontology.net/realmGeol/Window
+soreag:Window rdf:type owl:Class ;
+              rdfs:subClassOf soreag:DenudationalFeature ;
+              dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+              dcterms:source <http://www.glossaryofgeology.org> ;
+              skos:altLabel "fenster"@en ;
+              skos:definition "An eroded area of a thrust sheet or nappe that displays the rocks beneath the thrust sheet. (Neuendorf et al., 2011)"@en ;
+              skos:prefLabel "window"@en .
+
+
+###  http://www.opengis.net/ont/geosparql#Feature
+geo:Feature rdf:type owl:Class .
+
+
+###  http://www.w3.org/1999/02/22-rdf-syntax-ns#Seq
+rdf:Seq rdf:type owl:Class .
+
+
+###  https://schema.org/Organization
+sdo:Organization rdf:type owl:Class .
+
+
+###  https://schema.org/Person
+sdo:Person rdf:type owl:Class .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://www.glossaryofgeology.org
+<http://www.glossaryofgeology.org> rdf:type owl:NamedIndividual ,
+                                            sohur:Publication ;
+                                   dcterms:creator [ rdf:type rdf:Seq ;
+                                                     rdf:_1 "James P. Mehl Jr." ;
+                                                     rdf:_2 "Julia A. Jackson" ;
+                                                     rdf:_3 "Klaus K.E. Neuendorf"
+                                                   ] ;
+                                   dcterms:date "2011"^^xsd:gYear ;
+                                   dcterms:identifier "ISBN: 978-0-922152-92-6" ;
+                                   dcterms:publisher "American Geosciences Institute, Alexandria, Virginia USA" ;
+                                   dcterms:title "Glossary of Geology (Fifth Edition Revised)" ;
+                                   dcterms:type biblio:Book ,
+                                                wiki:Q571 .
+
+
+###  http://doi.org/10.22459/SN.08.2012
+<http://doi.org/10.22459/SN.08.2012> rdf:type owl:NamedIndividual ,
+                                              sohur:Publication ;
+                                     dcterms:creator "Richard S. Blewett" ;
+                                     dcterms:date "2012"^^xsd:gYear ;
+                                     dcterms:identifier "ISBN: 9781921862823" ;
+                                     dcterms:publisher "ANU Press" ;
+                                     dcterms:title "Shaping a Nation: A Geology of Australia" ;
+                                     dcterms:type biblio:Book ,
+                                                  wiki:Q571 .
+
+
+###  http://linked.data.gov.au/org/ga
+<http://linked.data.gov.au/org/ga> rdf:type owl:NamedIndividual ,
+                                            sdo:Organization ;
+                                   sdo:name "Geoscience Australia" .
+
+
+###  http://linked.data.gov.au/org/gsq
+<http://linked.data.gov.au/org/gsq> rdf:type owl:NamedIndividual ,
+                                             sdo:Organization ;
+                                    sdo:email <mailto:geological_info@dnrme.qld.gov.au> ;
+                                    sdo:name "Geological Survey of Queensland" .
+
+
+###  http://pid.geoscience.gov.au/dataset/ga/14909
+<http://pid.geoscience.gov.au/dataset/ga/14909> rdf:type owl:NamedIndividual ,
+                                                         sohur:Publication ;
+                                                dcterms:creator [ rdf:type rdf:Seq ;
+                                                                  rdf:_1 "R.D Shaw" ;
+                                                                  rdf:_2 "P. Wellman" ;
+                                                                  rdf:_3 "P.J. Gunn" ;
+                                                                  rdf:_4 "A.J. Whitaker" ;
+                                                                  rdf:_5 "C. Tarlowski" ;
+                                                                  rdf:_6 "M.P. Morse"
+                                                                ] ;
+                                                dcterms:date "1996"^^xsd:gYear ;
+                                                dcterms:identifier "Record 1996/30" ;
+                                                dcterms:publisher "Geoscience Australia" ;
+                                                dcterms:title "Australian Crustal Elements Map" ;
+                                                dcterms:type "" .
+
+
+###  http://pid.geoscience.gov.au/dataset/ga/70149
+<http://pid.geoscience.gov.au/dataset/ga/70149> rdf:type owl:NamedIndividual ,
+                                                         sohur:Publication ;
+                                                dcterms:creator [ rdf:type rdf:Seq ;
+                                                                  rdf:_1 "R.J. Korsch" ;
+                                                                  rdf:_2 "N. Kositcin"
+                                                                ] ;
+                                                dcterms:date "2010"^^xsd:gYear ;
+                                                dcterms:publisher <http://linked.data.gov.au/org/ga> ;
+                                                dcterms:title "South Australia Seismic and MT Workshop 2010: Extended Abstracts" ;
+                                                dcterms:type biblio:Book ,
+                                                             wiki:Q571 .
+
+
+###  http://sweetontology.net/realmGeol/Crust
+soreag:Crust rdf:type owl:NamedIndividual .
+
+
+###  http://www.stratigraphy.org/index.php/ics-stratigraphicguide
+<http://www.stratigraphy.org/index.php/ics-stratigraphicguide> rdf:type owl:NamedIndividual ,
+                                                                        sohur:Publication ;
+                                                               dcterms:created "2013"^^xsd:gYear ;
+                                                               dcterms:creator "International Commission on Stratigraphy" ;
+                                                               dcterms:publisher "International Commission on Stratigraphy" ;
+                                                               dcterms:type sdo:WebSite ,
+                                                                            wiki:Q35127 ;
+                                                               sdo:lastReviewed "2020-02-20"^^xsd:date .
+
+
+###  https://doi.org/10.1.1.605.7824
+<https://doi.org/10.1.1.605.7824> rdf:type owl:NamedIndividual ,
+                                           sohur:Publication ;
+                                  npg:hasJournal [ rdf:type npg:Journal ;
+                                                   npg:issue "2" ;
+                                                   npg:pages "106–116" ;
+                                                   npg:volume "6" ;
+                                                   sdo:name "Stratigraphy"
+                                                 ] ;
+                                  dcterms:creator "Donald E. Owen" ;
+                                  dcterms:date "2009"^^xsd:gYear ;
+                                  dcterms:publisher "North American Commission on Stratigraphic Nomenclature" ;
+                                  dcterms:title "How to use stratigraphic terminology in papers" ;
+                                  dcterms:type biblio:Article ,
+                                               wiki:Q191067 ;
+                                  sdo:url <https://www.semanticscholar.org/paper/How-to-use-stratigraphic-terminology-in-papers%2C-and-Owen/87841f3c9bbf290f2e80cfb7c8841b27a5342391> .
+
+
+###  https://doi.org/10.1007/978-3-662-03999-1
+<https://doi.org/10.1007/978-3-662-03999-1> rdf:type owl:NamedIndividual ,
+                                                     sohur:Publication ;
+                                            dcterms:creator "Andrew D. Miall" ;
+                                            dcterms:date "2000"^^xsd:gYear ;
+                                            dcterms:identifier "ISBN: 978-3-540-65790-3" ;
+                                            dcterms:publisher "Springer-Verlag Berlin Heidelberg" ;
+                                            dcterms:title "Principles of Sedimentary Basin Analysis. Third, Updated and Enlarged Edition" ;
+                                            dcterms:type biblio:Book ,
+                                                         wiki:Q571 .
+
+
+###  https://doi.org/10.1016/j.revpalbo.2014.04.002
+<https://doi.org/10.1016/j.revpalbo.2014.04.002> rdf:type owl:NamedIndividual ,
+                                                          sohur:Publication ;
+                                                 npg:hasJournal [ rdf:type npg:Journal ;
+                                                                  npg:pages "18-37" ;
+                                                                  npg:volume "207" ;
+                                                                  sdo:name "Review of Palaeobotany and Palynology"
+                                                                ] ;
+                                                 dcterms:creator [ rdf:type rdf:Seq ;
+                                                                   rdf:_1 "Benjamin Bomfleur" ,
+                                                                          "Hans Kerp" ,
+                                                                          "Joerg W. Schneider" ,
+                                                                          "John L. McKellar" ,
+                                                                          "Lothar Viereck" ,
+                                                                          "Robert Schöner"
+                                                                 ] ;
+                                                 dcterms:date "2014"^^xsd:gYear ;
+                                                 dcterms:publisher "Elsevier" ;
+                                                 dcterms:title "From the Transantarctic Basin to the Ferrar Large Igneous Province - New Palynostratigraphic Age Constraints for Triassic–Jurassic Sedimentation and Magmatism in East Antarctica" ;
+                                                 dcterms:type biblio:Article ,
+                                                              wiki:Q191067 .
+
+
+###  https://doi.org/10.1016/j.tecto.2012.02.022
+<https://doi.org/10.1016/j.tecto.2012.02.022> rdf:type owl:NamedIndividual ,
+                                                       sohur:Publication ;
+                                              npg:hasJournal [ rdf:type npg:Journal ;
+                                                               npg:pages "76-99" ;
+                                                               npg:volume "572-573" ;
+                                                               sdo:name "Tectonophysics"
+                                                             ] ;
+                                              dcterms:creator [ rdf:type rdf:Seq ;
+                                                                rdf:_1 "R.J. Korsch" ;
+                                                                rdf:_10 "A.J. Meixner" ;
+                                                                rdf:_11 "R. Chopping" ;
+                                                                rdf:_12 "P.A. Henson" ;
+                                                                rdf:_13 "D.C. Champion" ;
+                                                                rdf:_14 "L.J. Hutton" ;
+                                                                rdf:_15 "R. Wormald" ;
+                                                                rdf:_16 "J. Holzschuh" ;
+                                                                rdf:_17 "R.D. Costelloe" ;
+                                                                rdf:_2 "D.L. Huston" ;
+                                                                rdf:_3 "R.A. Henderson" ;
+                                                                rdf:_4 "R.S. Blewett" ;
+                                                                rdf:_5 "I.W. Withnall" ;
+                                                                rdf:_6 "C.L. Fergusson" ;
+                                                                rdf:_7 "W.J. Collins" ;
+                                                                rdf:_8 "E. Saygina" ;
+                                                                rdf:_9 "N. Kositcin"
+                                                              ] ;
+                                              dcterms:date "2012"^^xsd:gYear ;
+                                              dcterms:publisher "Elsevier" ;
+                                              dcterms:title "Crustal Architecture and Geodynamics of North Queensland, Australia: Insights from Deep Seismic Reflection Profiling" ;
+                                              dcterms:type biblio:Article ,
+                                                           wiki:Q191067 .
+
+
+###  https://doi.org/10.1080/01916122.2012.718609
+<https://doi.org/10.1080/01916122.2012.718609> rdf:type owl:NamedIndividual ,
+                                                        sohur:Publication ;
+                                               npg:hasJournal [ rdf:type npg:Journal ;
+                                                                npg:pages "77-114" ;
+                                                                npg:volume "37" ;
+                                                                sdo:name "Palynology"
+                                                              ] ;
+                                               dcterms:creator [ rdf:type rdf:Seq ;
+                                                                 rdf:_1 "Noel J. de Jersey" ;
+                                                                 rdf:_2 "John L. McKellar"
+                                                               ] ;
+                                               dcterms:date "2013"^^xsd:gYear ;
+                                               dcterms:publisher "Taylor & Francis" ;
+                                               dcterms:title "Palynology of the Triassic–Jurassic transition in southeastern Queensland, Australia, and correlation with New Zealand" ;
+                                               dcterms:type biblio:Article ,
+                                                            wiki:Q191067 .
+
+
+###  https://doi.org/10.1080/08120098508729316
+<https://doi.org/10.1080/08120098508729316> rdf:type owl:NamedIndividual ,
+                                                     sohur:Publication ;
+                                            npg:hasJournal [ rdf:type npg:Journal ;
+                                                             npg:issue "2" ;
+                                                             npg:pages "83-106" ;
+                                                             npg:volume "32" ;
+                                                             sdo:name "Australian Journal of Earth Sciences"
+                                                           ] ;
+                                            dcterms:creator "H. R. E. Staines" ;
+                                            dcterms:date "1985"^^xsd:gYear ;
+                                            dcterms:publisher "Geological Society of Australia" ;
+                                            dcterms:title "Field Geologist's Guide to Lithostratigraphic Nomenclature in Australia" ;
+                                            dcterms:type biblio:Article ,
+                                                         wiki:Q191067 .
+
+
+###  https://doi.org/10.1080/11035897.2016.1178666
+<https://doi.org/10.1080/11035897.2016.1178666> rdf:type owl:NamedIndividual ,
+                                                         sohur:Publication ;
+                                                npg:hasJournal [ rdf:type npg:Journal ;
+                                                                 npg:issue "1" ;
+                                                                 npg:pages "3-20" ;
+                                                                 npg:volume "139" ;
+                                                                 sdo:name "GFF"
+                                                               ] ;
+                                                dcterms:creator "Risto A. Kumpulainen" ;
+                                                dcterms:date "2017"^^xsd:gYear ;
+                                                dcterms:publisher "Taylor & Francis" ;
+                                                dcterms:title "Guide for geological nomenclature in Sweden" ;
+                                                dcterms:type biblio:Article ,
+                                                             wiki:Q191067 .
+
+
+###  https://doi.org/10.1093/acref/9780199653065.001.0001
+<https://doi.org/10.1093/acref/9780199653065.001.0001> rdf:type owl:NamedIndividual ,
+                                                                sohur:Publication ;
+                                                       dcterms:creator "Michael Allaby" ;
+                                                       dcterms:date "2013"^^xsd:gYear ;
+                                                       dcterms:description "Online version" ;
+                                                       dcterms:identifier "ISBN: 9780199653065" ;
+                                                       dcterms:publisher "Oxford University Press" ;
+                                                       dcterms:title "A Dictionary of Geology and Earth Sciences (Fourth Edition)" ;
+                                                       dcterms:type biblio:Book ,
+                                                                    wiki:Q571 .
+
+
+###  https://doi.org/10.1127/0078-0421/2011/0011
+<https://doi.org/10.1127/0078-0421/2011/0011> rdf:type owl:NamedIndividual ,
+                                                       sohur:Publication ;
+                                              npg:hasJournal [ rdf:type npg:Journal ;
+                                                               npg:issue "3" ;
+                                                               npg:pages "173-245" ;
+                                                               npg:volume "44" ;
+                                                               sdo:name "Newsletters on Stratigraphy"
+                                                             ] ;
+                                              dcterms:creator [ rdf:type rdf:Seq ;
+                                                                rdf:_1 "Andrew D. Miall" ;
+                                                                rdf:_2 "André Strasser" ;
+                                                                rdf:_3 "Christopher G.S.t.C. Kendall" ;
+                                                                rdf:_4 "Henry W. Posamentier" ;
+                                                                rdf:_5 "Maurice E. Tucker" ;
+                                                                rdf:_6 "Octavian Catuneanu" ;
+                                                                rdf:_7 "William E. Galloway"
+                                                              ] ;
+                                              dcterms:date "2011"^^xsd:gYear ;
+                                              dcterms:publisher "Schweizerbart Science Publishers" ;
+                                              dcterms:title "Sequence Stratigraphy: Methodology and Nomenclature" ;
+                                              dcterms:type biblio:Article ,
+                                                           wiki:Q191067 .
+
+
+###  https://doi.org/10.1130/9780813774022
+<https://doi.org/10.1130/9780813774022> rdf:type owl:NamedIndividual ,
+                                                 sohur:Publication ;
+                                        dcterms:creator "Amos Salvador" ;
+                                        dcterms:date "2013"^^xsd:gYear ;
+                                        dcterms:identifier "ISBN: 978-0-813-77402-2" ;
+                                        dcterms:publisher "Geological Society of America" ;
+                                        dcterms:title "International Stratigraphic Guide" ;
+                                        dcterms:type biblio:Book ,
+                                                     wiki:Q571 .
+
+
+###  https://doi.org/10.1306/05230505015
+<https://doi.org/10.1306/05230505015> rdf:type owl:NamedIndividual ,
+                                               sohur:Publication ;
+                                      npg:hasJournal [ rdf:type npg:Journal ;
+                                                       npg:issue "11" ;
+                                                       npg:pages "1547–1591" ;
+                                                       npg:volume "89" ;
+                                                       sdo:name "AAPG Bulletin"
+                                                     ] ;
+                                      dcterms:creator [ rdf:type rdf:Seq ;
+                                                        rdf:_1 "Alfred C. Lenz" ;
+                                                        rdf:_2 "Brian R. Pratt" ;
+                                                        rdf:_3 "Bruce R. Wardlaw" ;
+                                                        rdf:_4 "Ernest A. Mancini" ;
+                                                        rdf:_5 "Ismael Ferrusquiacutea-Villafranca" ;
+                                                        rdf:_6 "James O. Jones" ;
+                                                        rdf:_7 "Lucy E. Edwards" ;
+                                                        rdf:_8 "R. Michael Easton"
+                                                      ] ;
+                                      dcterms:date "2005"^^xsd:gYear ;
+                                      dcterms:publisher "American Association of Petroleum Geologists" ;
+                                      dcterms:title "North American Commission on Stratigraphic Nomenclature" ;
+                                      dcterms:type biblio:Article ,
+                                                   wiki:Q191067 .
+
+
+###  https://orcid.org/0000-0001-5489-9590
+<https://orcid.org/0000-0001-5489-9590> rdf:type owl:NamedIndividual ,
+                                                 sdo:Person ;
+                                        sdo:affiliation <http://linked.data.gov.au/org/gsq> ;
+                                        sdo:email <mailto:john.mckellar@dnrme.qld.gov.au> ;
+                                        sdo:name "John L. McKellar" .
+
+
+###  https://orcid.org/0000-0002-8742-7730
+<https://orcid.org/0000-0002-8742-7730> rdf:type owl:NamedIndividual ,
+                                                 sdo:Person ;
+                                        sdo:affiliation [ rdf:type sdo:Organization ;
+                                                          sdo:name "SURROUND Australia Pty Ltd" ;
+                                                          sdo:url <https://surroundaustralia.com>
+                                                        ] ;
+                                        sdo:email <mailto:nicholas.car@surroundaustralia.com> ;
+                                        sdo:name "Nicholas J. Car" .
+
+
+###  https://www.elsevier.com/books/the-geologic-time-scale-2012/gradstein/978-0-444-59425-9
+<https://www.elsevier.com/books/the-geologic-time-scale-2012/gradstein/978-0-444-59425-9> rdf:type owl:NamedIndividual ,
+                                                                                                   sohur:Publication ;
+                                                                                          dcterms:creator "F.M. Gradstein" ,
+                                                                                                          "Gabi Ogg" ,
+                                                                                                          "J.G. Ogg" ,
+                                                                                                          "Mark Schmitz" ;
+                                                                                          dcterms:date "2012-07-31"^^xsd:date ;
+                                                                                          dcterms:identifier "ISBN: 978-0-444-59448-8" ;
+                                                                                          dcterms:publisher "Elsevier, Amsterdam" ;
+                                                                                          dcterms:title "The Geologic Time Scale 2012" ;
+                                                                                          dcterms:type biblio:Book ,
+                                                                                                       wiki:Q571 .
+
+
+[ rdf:type sohur:Publication ;
+  dcterms:creator "Geological Society of Australia" ;
+  dcterms:date "2020"^^xsd:gYear ;
+  dcterms:publisher "Geological Society of Australia" ;
+  dcterms:title "ACT Geoheritage" ;
+  dcterms:type wiki:Q35127 ;
+  sdo:url <https://www.gsa.org.au/Public/Geoheritage/ACT_Geoheritage/Public/Geoheritage/ACT_Geoheritage.aspx?hkey=396c84ce-9cb1-47d9-91c7-5770f97a8896>
+] .
+
+[ rdf:type sohur:Publication ;
+   dcterms:creator "Geological Society of Australia" ;
+   dcterms:date "2020"^^xsd:gYear ;
+   dcterms:publisher "Geological Society of Australia" ;
+   dcterms:title "ACT Geoheritage" ;
+   dcterms:type wiki:Q35127 ;
+   sdo:url <https://www.gsa.org.au/Public/Geoheritage/ACT_Geoheritage/Public/Geoheritage/ACT_Geoheritage.aspx?hkey=396c84ce-9cb1-47d9-91c7-5770f97a8896>
+ ] .
+
+[ rdf:type sohur:Publication ;
+   dcterms:creator "Geological Society of Australia" ;
+   dcterms:date "2020"^^xsd:gYear ;
+   dcterms:publisher "Geological Society of Australia" ;
+   dcterms:title "Geotourism and Geotrails" ;
+   dcterms:type wiki:Q35127 ;
+   sdo:url <https://www.gsa.org.au/Public/Geotourism/Geotourism%20and%20Geotrails/Public/Geotourism/Geotourism%20and%20Geotrails.aspx?hkey=f3ee82ea-de9a-44eb-82f7-377d2d28d2ba>
+ ] .
+
+[ rdf:type sohur:Publication ;
+   dcterms:creator "Geological Society of Australia" ;
+   dcterms:date "2020"^^xsd:gYear ;
+   dcterms:publisher "Geological Society of Australia" ;
+   dcterms:title "Geotourism and Geotrails" ;
+   dcterms:type wiki:Q35127 ;
+   sdo:url <https://www.gsa.org.au/Public/Geotourism/Geotourism%20and%20Geotrails/Public/Geotourism/Geotourism%20and%20Geotrails.aspx?hkey=f3ee82ea-de9a-44eb-82f7-377d2d28d2ba>
+ ] .
+
+[ rdf:type sdo:Organization ;
+   sdo:identifier <http://linked.data.gov.au/org/gsq> ;
+   sdo:name "Geological Survey of Queensland"
+ ] .
+
+#################################################################
+#    Annotations
+#################################################################
+
+soreag:Crust rdfs:label "crust"@en .
+
+
+owl:Nothing skos:definition ""@en .
+
+
+owl:Thing skos:definition ""@en .
 
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/src/realmGeolBasin.ttl
+++ b/src/realmGeolBasin.ttl
@@ -4,6 +4,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix soreag: <http://sweetontology.net/realmGeol/> .
 @prefix somarock: <http://sweetontology.net/matrRock/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -39,50 +40,54 @@ sorelph:hasPlanetaryStructure rdf:type owl:ObjectProperty .
 
 ###  http://sweetontology.net/realmGeolBasin/BackArcBasin
 soreagb:BackArcBasin rdf:type owl:Class ;
-                   rdfs:subClassOf soreagb:Basin ;
+                   rdfs:subClassOf soreagb:SedimentaryBasin ;
                    rdfs:label "back arc basin"@en .
 
 
-###  http://sweetontology.net/realmGeolBasin/Basin
-soreagb:Basin rdf:type owl:Class ;
+###  http://sweetontology.net/realmGeolBasin/SedimentaryBasin
+soreagb:SedimentaryBasin rdf:type owl:Class ;
             rdfs:subClassOf soreag:GeologicFeature ,
                             <http://sweetontology.net/reprSpaceGeometry/Depression> ;
-            rdfs:label "basin"@en .
+            dcterms:source <https://doi.org/10.1007/978-3-662-03999-1> ;
+            rdfs:subClassOf soreag:GeologicProvince ;
+            skos:definition "A low area in the Earth’s crust, of tectonic origin, in which sediments accumulate. Sedimentary basins range in size from small continental basins to large oceanic basins. The essential element of the concept is tectonic creation of relief, to provide both a source of sediment and a relatively low place for the deposition of that sediment. (After Miall, 2000)"@en ;
+            skos:prefLabel "sedimentary basin"@en ;
+            skos:altLabel "basin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/FlyschBasin
 soreagb:FlyschBasin rdf:type owl:Class ;
-                  rdfs:subClassOf soreagb:Basin ;
+                  rdfs:subClassOf soreagb:SedimentaryBasin ;
                   rdfs:label "flysch basin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/ForeArcBasin
 soreagb:ForeArcBasin rdf:type owl:Class ;
-                   rdfs:subClassOf soreagb:Basin ;
+                   rdfs:subClassOf soreagb:SedimentaryBasin ;
                    rdfs:label "fore arc basin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/ForelandBasin
 soreagb:ForelandBasin rdf:type owl:Class ;
-                    rdfs:subClassOf soreagb:Basin ;
+                    rdfs:subClassOf soreagb:SedimentaryBasin ;
                     rdfs:label "foreland basin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/IntraArcBasin
 soreagb:IntraArcBasin rdf:type owl:Class ;
-                    rdfs:subClassOf soreagb:Basin ;
+                    rdfs:subClassOf soreagb:SedimentaryBasin ;
                     rdfs:label "intra arc basin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/IntracratonicBasin
 soreagb:IntracratonicBasin rdf:type owl:Class ;
-                         rdfs:subClassOf soreagb:Basin ;
+                         rdfs:subClassOf soreagb:SedimentaryBasin ;
                          rdfs:label "intracratonic basin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/PeripheralForelandBasin
 soreagb:PeripheralForelandBasin rdf:type owl:Class ;
-                              rdfs:subClassOf soreagb:Basin ,
+                              rdfs:subClassOf soreagb:SedimentaryBasin ,
                                               [ rdf:type owl:Restriction ;
                                                 owl:onProperty sorelch:hasSubstance ;
                                                 owl:allValuesFrom somarock:Molasse
@@ -96,25 +101,49 @@ soreagb:PeripheralForelandBasin rdf:type owl:Class ;
 
 ###  http://sweetontology.net/realmGeolBasin/RetroarcForelandBasin
 soreagb:RetroarcForelandBasin rdf:type owl:Class ;
-                            rdfs:subClassOf soreagb:Basin ;
+                            rdfs:subClassOf soreagb:SedimentaryBasin ;
                             rdfs:label "retroarc foreland basin"@en .
+
+
+###  http://sweetontology.net/realmGeolBasin/Subbasin
+soreagb:Subbasin rdf:type owl:Class ;
+                     dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                     rdfs:subClassOf soreagb:SedimentaryBasin ;
+                     skos:altLabel "sub-basin"@en ;
+                     skos:definition "A sedimentary basin may be subdivided into two or more subbasins that have separate depocentres and are separated from one another by some tectonic/structural element, such as a fault or basement high. (Definition created here: Paul Blake, John McKellar)"@en ;
+                     skos:prefLabel "subbasin"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/SuccessorBasin
 soreagb:SuccessorBasin rdf:type owl:Class ;
-                     rdfs:subClassOf soreagb:Basin ;
+                     rdfs:subClassOf soreagb:SedimentaryBasin ;
                      rdfs:label "successor basin"@en .
 
 
+###  http://sweetontology.net/realmGeolBasin/Superbasin
+soreagb:Superbasin rdf:type owl:Class ;
+                     dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                     rdfs:subClassOf soreagb:SedimentaryBasin ;
+                     skos:definition "A superbasin is a hierarchial term applied to  a group of largely interconnected or associated sedimentary basins of the same or similar age. Its component basins may be separated or partially separated by tectonic elements that define 'boundaries'  between them, or they may have been subjected to somewhat different geological influences. In the Australian Mesozoic, the Great Australian Superbasin, composed of the Nambour, Clarence-Moreton, Surat, Eromanga, Carpentaria and other basins, is a prime example, variously covering a geographically-extensive area in parts of Queensland, the Northern Territory, New South Wales and South Australia. (Definition created here)"@en ;
+                     skos:prefLabel "superbasin"@en .
+
 ###  http://sweetontology.net/realmGeolBasin/TranspressionalBasin
 soreagb:TranspressionalBasin rdf:type owl:Class ;
-                           rdfs:subClassOf soreagb:Basin ;
+                           rdfs:subClassOf soreagb:SedimentaryBasin ;
                            rdfs:label "transpressional basin"@en .
+
+
+###  http://sweetontology.net/realmGeolBasin/Trough
+soreagb:Trough rdf:type owl:Class ;
+                     dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+                     rdfs:subClassOf soreagb:SedimentaryBasin ;
+                     skos:definition "A trough (in the continental realm) is an elongate region of the lithosphere that has undergone subsidence because of faulting along one or both of its elongate margins, permitting the accumulation of sediments and the subsequent formation of sedimentary rocks. Troughs are generally grabens or half-grabens, sometimes associated with initial magmatism, that have formed under extensional or transtensional tectonic conditions and may be part of, or associated with, the formation, and subsequent evolution, of larger sedimentary-basin/rifting systems or basin-and-range (western-North-America) type settings. (Definition created here)"@en ;
+                     skos:prefLabel "trough"@en .
 
 
 ###  http://sweetontology.net/realmGeolBasin/TranstensionalBasin
 soreagb:TranstensionalBasin rdf:type owl:Class ;
-                          rdfs:subClassOf soreagb:Basin ;
+                          rdfs:subClassOf soreagb:SedimentaryBasin ;
                           rdfs:label "transtensional basin"@en .
 
 

--- a/src/realmGeolContinental.ttl
+++ b/src/realmGeolContinental.ttl
@@ -1,21 +1,26 @@
 @prefix : <http://sweetontology.net/realmGeolContinental/> .
 @prefix matrRockIgneous: <http://sweetontology.net/matrRockIgneous/> .
+@prefix biblio: <http://purl.org/net/biblio#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sorealt: <http://sweetontology.net/realmLandTectonic/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix soma: <http://sweetontology.net/matr/> .
 @prefix soreagcont: <http://sweetontology.net/realmGeolContinental/> .
 @prefix soreag: <http://sweetontology.net/realmGeol/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sohur: <http://sweetontology.net/humanResearch/> .
 @prefix sorel: <http://sweetontology.net/rela/> .
 @prefix sostrg: <http://sweetontology.net/stateRoleGeographic/> .
 @prefix soreagb: <http://sweetontology.net/realmGeolBasin/> .
 @prefix sorelch: <http://sweetontology.net/relaChemical/> .
 @prefix sorelph: <http://sweetontology.net/relaPhysical/> .
 @prefix sorelsc: <http://sweetontology.net/relaSci/> .
+@prefix wiki: <https://www.wikidata.org/wiki/> .
 @base <http://sweetontology.net/realmGeolContinental> .
 
 <http://sweetontology.net/realmGeolContinental> rdf:type owl:Ontology ;
@@ -127,12 +132,18 @@ soreagcont:Craton rdf:type owl:Class ;
                               owl:onProperty sorelph:hasPlanetaryStructure ;
                               owl:allValuesFrom soreagcont:Shield
                             ] ;
-            rdfs:label "craton"@en .
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <http://www.glossaryofgeology.org> ;
+            skos:definition "A craton is part of Earth's continental crust that has attained stability and has been little deformed for a prolonged period. Cratons include shield areas, where Precambrian rocks are exposed, and platform areas, where Precambrian rocks are overlain by a thin layer of Phanerozoic strata. (Neuendorf et al., 2011)"@en ;                            
+            skos:prefLabel "craton"@en .
 
 
 ###  http://sweetontology.net/realmGeolContinental/Shield
 soreagcont:Shield rdf:type owl:Class ;
             rdfs:subClassOf soreag:GeologicProvince ;
+            dcterms:contributor <http://linked.data.gov.au/org/gsq> ;
+            dcterms:source <http://www.glossaryofgeology.org> ;
+            skos:definition "A large area of exposed basement rock in a craton, commonly with a very gently convex surface, surrounded by sediment covered platforms. The rocks of virtually all shield areas are Precambrian. (Neuendorf et al., 2011)"@en ;
             rdfs:label "shield"@en .
 
 
@@ -145,6 +156,21 @@ soreagcont:StableContinent rdf:type owl:Class ;
                                      ] ;
                      rdfs:label "stable continent"@en .
 
+###  http://sweetontology.net/realmGeolContinental/Supercraton
+soreagcont:Supercraton rdf:type owl:Class ;
+                     rdfs:subClassOf soreag:GeologicProvince ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty sorel:hasPart ;
+                                       owl:allValuesFrom soreagcont:Craton
+                                     ] ,
+                                     [ rdf:type owl:Restriction ;
+                                       owl:onProperty sorel:hasPart ;
+                                       owl:minCardinality "2"^^xsd:int
+                                     ] ;
+                     dcterms:source <http://doi.org/10.22459/SN.08.2012> ;
+                     rdfs:subClassOf soreag:GeologicProvince ;
+                     skos:definition "A large, ancestral (largely Archean) landmass consisting of two or more cratons. (Blewett, 2012)"@en ;
+                     skos:prefLabel "supercraton"@en .
 
 ###  http://sweetontology.net/realmGeolContinental/Supercontinent
 soreagcont:Supercontinent rdf:type owl:Class ;
@@ -171,5 +197,29 @@ sorealt:Rift rdf:type owl:Class .
 ###  http://sweetontology.net/stateRoleGeographic/Margin
 sostrg:Margin rdf:type owl:Class .
 
+<http://doi.org/10.22459/SN.08.2012> 
+  rdf:type sohur:Publication , owl:NamedIndividual ;
+  dcterms:creator "Richard S. Blewett" ;
+  dcterms:date "2012"^^xsd:gYear ;
+  dcterms:identifier "ISBN: 9781921862823" ;
+  dcterms:publisher "ANU Press" ;
+  dcterms:title "Shaping a Nation: A Geology of Australia" ;
+  dcterms:type biblio:Book ;
+  dcterms:type wiki:Q571 .
+
+<http://www.glossaryofgeology.org> 
+  rdf:type sohur:Publication , owl:NamedIndividual ;
+  dcterms:creator (
+      "Klaus K.E. Neuendorf"
+      "James P. Mehl Jr."
+      "Julia A. Jackson"
+    ) ;
+  dcterms:date "2011"^^xsd:gYear ;
+  dcterms:identifier "ISBN: 978-0-922152-92-6" ;
+  dcterms:publisher "American Geosciences Institute, Alexandria, Virginia USA" ;
+  dcterms:title "Glossary of Geology (Fifth Edition Revised)" ;
+  dcterms:type biblio:Book ;
+  dcterms:type wiki:Q571 ;
+.
 
 ###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi

--- a/src/realmGeolOrogen.ttl
+++ b/src/realmGeolOrogen.ttl
@@ -1,4 +1,9 @@
 @prefix : <http://sweetontology.net/realmGeolOrogen/> .
+@prefix biblio: <http://purl.org/net/biblio#> .
+@prefix npg: <http://ns.nature.com/terms/> .
+@prefix wiki: <https://www.wikidata.org/wiki/> .
+@prefix sdo: <https://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sophso: <http://sweetontology.net/phenSolid/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix sopropsdir: <http://sweetontology.net/propSpaceDirection/> .
@@ -9,6 +14,7 @@
 @prefix sorealt: <http://sweetontology.net/realmLandTectonic/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix sohur: <http://sweetontology.net/humanResearch/> .
 @prefix soma: <http://sweetontology.net/matr/> .
 @prefix sophg: <http://sweetontology.net/phenGeol/> .
 @prefix sorepsg: <http://sweetontology.net/reprSpaceGeometry/> .
@@ -42,7 +48,7 @@
                                                         <http://sweetontology.net/relaPhysical> ,
                                                         <http://sweetontology.net/relaSpace> ,
                                                         <http://sweetontology.net/reprSpaceGeometry> ;
-                                            rdfs:label "SWEET Ontology Realm Geologic Orogen" ;
+                                            skos:prefLabel "SWEET Ontology Realm Geologic Orogen" ;
                                             dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
                                             owl:versionInfo "3.5.0" .
 
@@ -74,13 +80,13 @@ sorelsp:hasAxis rdf:type owl:ObjectProperty .
 soreagor:Arc rdf:type owl:Class ;
         rdfs:subClassOf soreag:GeologicFeature ,
                         sorepsg:Arc ;
-        rdfs:label "arc"@en .
+        skos:prefLabel "arc"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/ArcAxis
 soreagor:ArcAxis rdf:type owl:Class ;
             rdfs:subClassOf sopropsdir:Axis ;
-            rdfs:label "arc axis"@en .
+            skos:prefLabel "arc axis"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/BackArc
@@ -88,14 +94,14 @@ soreagor:BackArc rdf:type owl:Class ;
             owl:equivalentClass soreagor:RearArc ,
                                 soreagor:RetroArc ;
             rdfs:subClassOf soreagor:Arc ;
-            rdfs:label "back arc"@en .
+            skos:prefLabel "back arc"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/ForeArc
 soreagor:ForeArc rdf:type owl:Class ;
             rdfs:subClassOf soreagor:Arc ,
                             sorealt:SupraSubductionZoneComplex ;
-            rdfs:label "fore arc"@en .
+            skos:prefLabel "fore arc"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/MagmaticArc
@@ -113,7 +119,7 @@ soreagor:MagmaticArc rdf:type owl:Class ;
                                   owl:onProperty sorelsp:hasAxis ;
                                   owl:allValuesFrom soreagor:ArcAxis
                                 ] ;
-                rdfs:label "magmatic arc"@en .
+                skos:prefLabel "magmatic arc"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/Orogen
@@ -151,23 +157,51 @@ soreagor:Orogen rdf:type owl:Class ;
                              owl:onProperty sorelph:hasPlanetaryStructure ;
                              owl:someValuesFrom sorealt:ThrustSystem
                            ] ;
-           rdfs:label "orogen"@en .
+           dcterms:source <http://www.glossaryofgeology.org> ;
+           dcterms:contributor <http://linked.data.gov.au/def/gsq> ;                           
+           skos:definition "An orogen (orogenic system, orogenic zone, orogenic belt) is a region in Earth’s lithosphere where a mountain belt is created by tectonic processes involving deformation, regional metamorphism, and associated magmatism, usually caused by convergence (± accretion and/or collision) between two tectonic plates or major crustal blocks. (Alt obsolete term: geosyncline). (Modified from Neuendorf et al., 2011; Hoy, pers. comm.)"@en ;                      
+           skos:prefLabel "orogen"@en .
 
+
+soreagor:OrogenicCollage rdf:type owl:Class ;
+            dcterms:source <http://www.glossaryofgeology.org> ;
+            dcterms:source <https://doi.org/10.1146/annurev-earth-082517-010146> ;
+            rdfs:subClassOf soreag:GeologicProvince ;
+            skos:definition "A patchwork-map pattern of accreted terranes, embracing a geotectonic assemblage of crustal blocks separated by major faults (Neuendorf et al., 2011). In eastern Australia, such a collage is represented by the Tasmanides, which is part of the larger-scale Terra Australis Orogen that developed along the southern Panthalassan (Paleo-Pacific) margin of Gondwana, and which comprises multiple metamorphic belts, fold-thrust belts, igneous provinces, and sedimentary basins that have been attributed to five Cambrian to Triassic subduction-related orogens: the Delamerian, Thomson, Lachlan, Mossman, and New England Orogens (Rosenbaum, 2018)"@en ;
+            skos:prefLabel "orogenic collage"@en ;
+.
+
+<https://doi.org/10.1146/annurev-earth-082517-010146>
+            a sohur:Publication ;
+            rdf:type owl:NamedIndividual ;
+            npg:hasJournal [
+              a npg:Journal ;
+              npg:pages "291-325" ;
+              npg:volume "46" ;
+              sdo:name "Annual Review of Earth and Planetary Sciences" ;
+            ] ;
+            dcterms:creator "Gideon Rosenbaum" ;
+            dcterms:date "2018"^^xsd:gYear ;
+            dcterms:publisher "Annual Reviews" ;
+            dcterms:title "The Tasmanides: Phanerozoic Tectonic Evolution of Eastern Australia" ;
+            dcterms:type biblio:Article ;
+            dcterms:type wiki:Q191067 ;
+.
 
 ###  http://sweetontology.net/realmGeolOrogen/RearArc
 soreagor:RearArc rdf:type owl:Class ;
-            rdfs:label "rear arc"@en .
+            skos:prefLabel "rear arc"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/RemnantArc
 soreagor:RemnantArc rdf:type owl:Class ;
                rdfs:subClassOf soreagor:Arc ;
-               rdfs:label "remnant arc"@en .
+               skos:prefLabel "remnant arc"@en .
 
 
 ###  http://sweetontology.net/realmGeolOrogen/RetroArc
 soreagor:RetroArc rdf:type owl:Class ;
-             rdfs:label "retro arc"@en .
+             skos:prefLabel "retro arc"@en .
 
 
 ###  http://sweetontology.net/realmLandTectonic/SupraSubductionZoneComplex

--- a/src/realmGeolOrogen.ttl
+++ b/src/realmGeolOrogen.ttl
@@ -162,7 +162,7 @@ soreagor:Orogen rdf:type owl:Class ;
            skos:definition "An orogen (orogenic system, orogenic zone, orogenic belt) is a region in Earth’s lithosphere where a mountain belt is created by tectonic processes involving deformation, regional metamorphism, and associated magmatism, usually caused by convergence (± accretion and/or collision) between two tectonic plates or major crustal blocks. (Alt obsolete term: geosyncline). (Modified from Neuendorf et al., 2011; Hoy, pers. comm.)"@en ;                      
            skos:prefLabel "orogen"@en .
 
-
+###  http://sweetontology.net/realmGeolOrogen/OrogenicCollage
 soreagor:OrogenicCollage rdf:type owl:Class ;
             dcterms:source <http://www.glossaryofgeology.org> ;
             dcterms:source <https://doi.org/10.1146/annurev-earth-082517-010146> ;

--- a/src/rela.ttl
+++ b/src/rela.ttl
@@ -73,6 +73,12 @@ sorel:partOf rdf:type owl:ObjectProperty ,
                      owl:TransitiveProperty ;
             rdfs:label "part of"@en .
 
+###  http://sweetontology.net/rela/hasPart
+sorel:hasPart rdf:type owl:ObjectProperty ,
+                     owl:TransitiveProperty ;
+            owl:inverseOf sorel:partOf ;
+            rdfs:label "has part"@en .            
+
 
 #################################################################
 #    Classes


### PR DESCRIPTION
This is a major update to *SWEET Ontology Realm Geologic* ontology and a couple of related ontologies. 

Within *SWEET Ontology Realm Geologic*, it provides a class hierarchy beneath the class `soreag:GeologicFeature` of about 50 classes, all with definitions drawn from literature which is cited. It also provides cited definitions for a few classes in the *SWEET Ontology Realm Geologic Basin*, *SWEET Ontology Realm Geologic Continental* & *SWEET Ontology Realm Geologic Orogen* ontologies.

It tidies up the top-level hierarchy of  *SWEET Ontology Realm Geologic* too by adding in explicit subclassing triples for classes for which these are inferred by reasoning. This helps with hierarchical display in tools such as Protege.

All changes are attributed to the Geological Survey of Queensland, Nicholas Car and John McKellar equally since John & I did the work for the GSQ.