### PR TITLE
Adding terms from ESIP harmonization cryo activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SWEET is governed by the [ESIP Semantic Technologies Committee](http://wiki.esip
 # Development
 Please see the [CONTRIBUTING documentation](https://github.com/ESIPFed/sweet/blob/master/CONTRIBUTING.md).
 
-Additionally, if you wish to discuss SWEET issues with the STC, please contact us via the [WG email list](http://lists.esipfed.org/mailman/listinfo/esip-semanticweb). 
+Additionally, if you wish to discuss SWEET issues with the STC, please contact us via the [WG email list](http://lists.esipfed.org/mailman/listinfo/esip-semantictech). 
 
 # Using local copies of ontology
 The sweetall.ttl ontology imports all the other sweet components via URL. If you are offline, or working on updates that require using the local copies of the ontology files, copy the catalog-v001.xml file from the root directory of the repository into the src directory before opening sweetall.ttl in Protege. 

--- a/src/phenCryo.ttl
+++ b/src/phenCryo.ttl
@@ -1,10 +1,12 @@
 @prefix : <http://sweetontology.net/phenCryo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sophsy: <http://sweetontology.net/phenSystem/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix soprocp: <http://sweetontology.net/procPhysical/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sophcr: <http://sweetontology.net/phenCryo/> .
@@ -41,33 +43,74 @@ sophcr:Calving rdf:type owl:Class ;
 ###  http://sweetontology.net/phenCryo/Englacial
 sophcr:Englacial rdf:type owl:Class ;
                 rdfs:subClassOf sophcr:GlacialProcess ;
-                rdfs:label "englacial"@en .
+                rdfs:label "englacial"@en ;
+                skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001622>;
+                skos:definition  [
+                  rdfs:comment  "A positional quality inhering in a bearer by virtue of the bearer being located within a glacier or ice sheet, between their summer surface or bed."@en ;
+                  dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                  dcterms:created "2020-04-09T10:12:52-08:00Z"^^xsd:dateTimeStamp ;
+                  dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                  prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001622> ;
+                ] .
 
 
 ###  http://sweetontology.net/phenCryo/Glacial
 sophcr:Glacial rdf:type owl:Class ;
               owl:equivalentClass sophcr:Glaciation ;
-              rdfs:label "glacial"@en .
+              rdfs:label "glacial"@en ;
+              skos:definition  [
+                rdfs:comment  "An environmental process which involves glaciers or ice sheets."@en ;
+                dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                dcterms:created "2020-04-09T10:14:10-08:00Z"^^xsd:dateTimeStamp ;
+                dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+              ] .
 
 
 ###  http://sweetontology.net/phenCryo/GlacialProcess
 sophcr:GlacialProcess rdf:type owl:Class ;
                      rdfs:subClassOf soprocp:PhysicalProcess ;
-                     rdfs:label "glacial process"@en .
+                     rdfs:label "glacial process"@en ;
+                     skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001655> ;
+                     skos:definition  [
+                       rdfs:comment  "An environmental process which involves glaciers or ice sheets."@en ;
+                       dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                       dcterms:created "2020-04-09T10:15:23-08:00Z"^^xsd:dateTimeStamp ;
+                       dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                       prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001655> ;
+                     ] .
 
 
 ###  http://sweetontology.net/phenCryo/Glaciation
 sophcr:Glaciation rdf:type owl:Class ;
                  rdfs:subClassOf sophcr:Accumulation ;
                  owl:disjointWith sophcr:GlacierRetreat ;
-                 rdfs:label "glaciation"@en .
+                 rdfs:label "glaciation"@en ;
+                 rdfs:seeAlso <https://github.com/ESIPFed/sweet/issues/185> ;
+                 skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000029> ;
+                 skos:definition  [
+                   rdfs:comment  "The process of glacier ice gain."@en ;
+                   dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                   dcterms:created "2020-04-09T10:17:32-08:00Z"^^xsd:dateTimeStamp ;
+                   dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                   prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001655> ;
+                 ] .
 
 
 ###  http://sweetontology.net/phenCryo/GlacierRetreat
 sophcr:GlacierRetreat rdf:type owl:Class ;
                      rdfs:subClassOf sophcr:GlacialProcess ,
+                                     sophsy:Retreat,
                                      soprocsc:Melting ;
-                     rdfs:label "glacier retreat"@en .
+                     rdfs:label "glacier retreat"@en ;
+                     rdfs:seeAlso <https://github.com/ESIPFed/sweet/issues/185> ;
+                     skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000029> ;
+                     skos:definition  [
+                       rdfs:comment  "The process of glacier ice loss."@en ;
+                       dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                       dcterms:created "2020-04-09T10:20:12-08:00Z"^^xsd:dateTimeStamp ;
+                       dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                       prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000029> ;
+                     ] .
 
 
 ###  http://sweetontology.net/phenCryo/IceCalving
@@ -77,14 +120,35 @@ sophcr:IceCalving rdf:type owl:Class ;
 
 ###  http://sweetontology.net/phenCryo/Periglacial
 sophcr:Periglacial rdf:type owl:Class ;
-                  rdfs:subClassOf sophcr:GlacialProcess ;
-                  rdfs:label "periglacial"@en .
+                  rdfs:subClassOf sophcr:PhysicalProcess ;
+                  owl:disjointWith sophcr:GlacialProcess ;
+                  rdfs:label "periglacial"@en ;
+                  skos:note "Subclass relation changed from Glacial Process to Physical Process because Periglacial involves frost action not associated with glacial processes"@en ;
+                  rdfs:seeAlso <https://github.com/ESIPFed/sweet/issues/185> ;
+                  skos:definition  [
+                    rdfs:comment  "A frost action process which occurs in cold environments which are not part of a glacier."@en ;
+                    rdfs:comment "The conditions, processes and landforms associated with cold, nonglacial environments."@en;
+                    dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                    dcterms:created "2020-04-09T10:24:28-08:00Z"^^xsd:dateTimeStamp ;
+                    dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                  ] .
 
 
 ###  http://sweetontology.net/phenCryo/Periglaciation
 sophcr:Periglaciation rdf:type owl:Class ;
-                     rdfs:subClassOf sophcr:Glaciation ;
-                     rdfs:label "periglaciation"@en .
+                     rdfs:subClassOf soprocp:PhysicalProcess ;
+                     owl:disjointWith sophcr:GlacialProcess ;
+                     rdfs:label "periglaciation"@en ;
+                     rdfs:seeAlso <https://github.com/ESIPFed/sweet/issues/185> ;
+                     skos:note "This is not a term found in any community thesaurus or dictionary i.e. GCMD, etc, or community of practice. Should be depricated in a future version of sweet. We consider it to be synonymous with glaciation in the ENVO crossreference"@en ;
+                     skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001659> ;
+                     skos:definition  [
+                       rdfs:comment  "Processes associated with cold, nonglacial environments"@en ;
+                       dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                       dcterms:created "2020-04-09T10:28:56-08:00Z"^^xsd:dateTimeStamp ;
+                       dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                     ] .
+
 
 
 ###  http://sweetontology.net/phenCryo/Proglacial

--- a/src/phenCryo.ttl
+++ b/src/phenCryo.ttl
@@ -98,7 +98,7 @@ sophcr:Glaciation rdf:type owl:Class ;
                    dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
                    dcterms:created "2020-04-09T10:17:32-08:00Z"^^xsd:dateTimeStamp ;
                    dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
-                   prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001655> ;
+                   prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000029> ;
                  ] .
 
 
@@ -109,13 +109,13 @@ sophcr:GlacierRetreat rdf:type owl:Class ;
                                      soprocsc:Melting ;
                      rdfs:label "glacier retreat"@en ;
                      rdfs:seeAlso <https://github.com/ESIPFed/sweet/issues/185> ;
-                     skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000029> ;
+                     skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001656> ;
                      skos:definition  [
                        rdfs:comment  "The process of glacier ice loss."@en ;
                        dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
                        dcterms:created "2020-04-09T10:20:12-08:00Z"^^xsd:dateTimeStamp ;
                        dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
-                       prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000029> ;
+                       prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001656> ;
                      ] .
 
 
@@ -144,7 +144,7 @@ sophcr:Periglacial rdf:type owl:Class ;
 sophcr:Periglaciation rdf:type owl:Class ;
                      rdfs:subClassOf soprocp:PhysicalProcess ;
                      owl:disjointWith sophcr:GlacialProcess ;
-                     rdfs:label "periglaciation"@en ;
+                     rdfs:label "obsolete periglaciation"@en ;
                      rdfs:seeAlso <https://github.com/ESIPFed/sweet/issues/185> ;
                      skos:note "This is not a term found in any community thesaurus or dictionary i.e. GCMD, etc, or community of practice. Should be depricated in a future version of sweet. We consider it to be synonymous with glaciation in the ENVO crossreference"@en ;
                      skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001659> ;
@@ -153,7 +153,8 @@ sophcr:Periglaciation rdf:type owl:Class ;
                        dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
                        dcterms:created "2020-04-09T10:28:56-08:00Z"^^xsd:dateTimeStamp ;
                        dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
-                     ] .
+                     ] ;
+                     owl:deprecated "true"^^xsd:boolean .
 
 
 

--- a/src/phenCryo.ttl
+++ b/src/phenCryo.ttl
@@ -40,7 +40,7 @@ sophcr:Calving rdf:type owl:Class ;
               rdfs:label "calving"@en .
 
 
-###  http://sweetontology.net/phenCryo/Englacial
+###  http://sweetontology.net/phenCryo/EnglacialProcess
 sophcr:Englacial rdf:type owl:Class ;
                 rdfs:subClassOf sophcr:GlacialProcess ;
                 rdfs:label "englacial"@en ;

--- a/src/phenCryo.ttl
+++ b/src/phenCryo.ttl
@@ -39,11 +39,17 @@ sophcr:Calving rdf:type owl:Class ;
                               soprocsc:Melting ;
               rdfs:label "calving"@en .
 
+###  http://sweetontology.net/phenCryo/Englacial
+sophcr:Englacial rdf:type owl:Class ;
+                owl:equivalentClass sophcr:EnglacialProcess ;
+                rdfs:label "englacial"@en ;
+                rdfs:comment "This class is deprecated in favor of the URI EnglacialProcess"@en ;
+                owl:deprecated "true"^^xsd:boolean .
 
 ###  http://sweetontology.net/phenCryo/EnglacialProcess
-sophcr:Englacial rdf:type owl:Class ;
+sophcr:EnglacialProcess rdf:type owl:Class ;
                 rdfs:subClassOf sophcr:GlacialProcess ;
-                rdfs:label "englacial"@en ;
+                rdfs:label "englacial process"@en ;
                 skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001622>;
                 skos:definition  [
                   rdfs:comment  "A positional quality inhering in a bearer by virtue of the bearer being located within a glacier or ice sheet, between their summer surface or bed."@en ;

--- a/src/realmCryo.ttl
+++ b/src/realmCryo.ttl
@@ -82,14 +82,13 @@ soreac:AccumulationZone rdf:type owl:Class ;
 soreac:AlpineTundra rdf:type owl:Class ;
                   rdfs:subClassOf soreac:Tundra ;
                   rdfs:label "alpine tundra"@en ;
-                  skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_3400001> ;
-                  skos:exactMatch <http://purl.obolibrary.org/obo/ENVO_3400001> ;
+                  skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001371> ;
                   skos:definition  [
-                        rdfs:comment  "An area of tundra which is present in a region subject to alpine conditions."@en ;
+                        rdfs:comment  "A tundra ecosystem which exists at high altitudes and where vegetation is stunted due to low temperatures and high winds."@en ;
                         dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
                         dcterms:created "2019-12-10T06:11:13-08:00Z"^^xsd:dateTimeStamp ;
                         dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
-                        prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_3400001> ;
+                        prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001371> ;
                       ] .
 
 

--- a/src/realmCryo.ttl
+++ b/src/realmCryo.ttl
@@ -154,7 +154,7 @@ soreac:FastIce rdf:type owl:Class ;
 soreac:Floe rdf:type owl:Class ;
           owl:equivalentClass soreac:IceFloe ;
           rdfs:subClassOf soreac:SeaIce ;
-          rdfs:label "floe"@en ;
+          rdfs:label "sea ice floe"@en ;
           skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000066> ;
           skos:definition  [
             rdfs:comment  "An ice floe which is formed from frozen sea water, and floats upon the surface of a marine water body."@en ;

--- a/src/realmCryo.ttl
+++ b/src/realmCryo.ttl
@@ -2,12 +2,14 @@
 @prefix sorepsmo: <http://sweetontology.net/reprSciModel/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sohur: <http://sweetontology.net/humanResearch/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix soreac: <http://sweetontology.net/realmCryo/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix sorel: <http://sweetontology.net/rela/> .
 @prefix sorelsp: <http://sweetontology.net/relaSpace/> .
 @prefix somaw: <http://sweetontology.net/matrWater/> .
@@ -50,57 +52,133 @@ sorelsp:inside rdf:type owl:ObjectProperty .
 ###  http://sweetontology.net/realmCryo/AblationZone
 soreac:AblationZone rdf:type owl:Class ;
                   rdfs:subClassOf soreac:GlacialRegion ;
-                  rdfs:label "ablation zone"@en .
+                  rdfs:label "ablation zone"@en ;
+                  skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01000914> ;
+                  skos:definition  [
+                   rdfs:comment  "An environmental zone which overlaps a glacier or an ice sheet, and in which ice loss exceeds ice gain."@en ;
+                   dcterms:source <https://en.wikipedia.org/wiki/Ablation_zone> ;
+                   dcterms:created "2019-12-10T06:11:13-08:00Z"^^xsd:dateTimeStamp ;
+                   dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                   prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01000914> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/AccumulationZone
 soreac:AccumulationZone rdf:type owl:Class ;
                       rdfs:subClassOf soreac:GlacialRegion ;
-                      rdfs:label "accumulation zone"@en .
+                      rdfs:label "accumulation zone"@en ;
+                      skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001352> ;
+                      rdfs:comment  "This zone usually occurs at higher elevations and generally overlaps the conversion of snow to glacial ice."@en ;
+                      skos:definition  [
+                        rdfs:comment  "An ice accumulation zone which overlaps part of a glacier."@en ;
+                        dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                        dcterms:created "2019-12-10T06:11:13-08:00Z"^^xsd:dateTimeStamp ;
+                        dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                        prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001352> ;
+                      ] .
 
 
 ###  http://sweetontology.net/realmCryo/AlpineTundra
 soreac:AlpineTundra rdf:type owl:Class ;
                   rdfs:subClassOf soreac:Tundra ;
-                  rdfs:label "alpine tundra"@en .
+                  rdfs:label "alpine tundra"@en ;
+                  skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_3400001> ;
+                  skos:exactMatch <http://purl.obolibrary.org/obo/ENVO_3400001> ;
+                  skos:definition  [
+                        rdfs:comment  "An area of tundra which is present in a region subject to alpine conditions."@en ;
+                        dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                        dcterms:created "2019-12-10T06:11:13-08:00Z"^^xsd:dateTimeStamp ;
+                        dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                        prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_3400001> ;
+                      ] .
 
 
 ###  http://sweetontology.net/realmCryo/Calf
 soreac:Calf rdf:type owl:Class ;
           rdfs:subClassOf soreac:SeaIce ;
-          rdfs:label "calf"@en .
-
+          rdfs:label "calf"@en ;
+          skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001506> ;
+          skos:definition  [
+                        rdfs:comment  "An ice mass which has calved off an larger mass of ice."@en ;
+                        rdfs:comment  "This definition is intentionally broad to include the multiple existing and used definitions of ice calfs."@en ;
+                        dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                        dcterms:created "2019-12-10T06:11:13-08:00Z"^^xsd:dateTimeStamp ;
+                        dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                        prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001506> ;
+                      ] .
 
 ###  http://sweetontology.net/realmCryo/CongelationIce
 soreac:CongelationIce rdf:type owl:Class ;
                     rdfs:subClassOf soreac:SeaIce ;
-                    rdfs:label "congelation ice"@en .
-
+                    rdfs:label "congelation ice"@en ;
+                    skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001512> ;
+                    rdfs:comment "Congelation ice usually forms through the fusion/coalescence of platelets into solid ice."@en ;
+                    skos:definition  [
+                        rdfs:comment  "Sea ice which 1) has formed on the submerged surface (i.e. the base) of an existing mass of sea ice and 2) is composed of columnar crystals due to the downward growth of the crystals into the water."@en ;
+                        dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                        dcterms:created "2019-12-10T08:05:43-08:00Z"^^xsd:dateTimeStamp ;
+                        dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                        prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001512> ;
+                      ] .
 
 ###  http://sweetontology.net/realmCryo/DriftIce
 soreac:DriftIce rdf:type owl:Class ;
               rdfs:subClassOf soreac:SeaIce ;
               owl:disjointWith soreac:FastIce ;
-              rdfs:label "drift ice"@en .
+              rdfs:label "drift ice"@en ;
+              skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001517> ;
+              rdfs:comment "Prior to approximately 2014, drift ice was synonymous with the various grades of pack ice, described as very open (with an ice concentration of 1/10 to 3/10), open (4/10 to 6/10, with many leads and polynyas and the floes generally not in contact with one another), close (7/10 to 8/10, composed of floes mostly in contact), very close (9/10 to less than 10/10), and compact (10/10, with no water visible, called consolidated pack ice if the floes are frozen together). This is deprecated, with pack ice now referring to drift ice with a concentration equal to or above 7/10; however, other usages are still common."@en;
+              skos:definition  [
+                rdfs:comment  "A floating mass of ice which is 1) unattached to land or land-fast ice and 2) moved by the action of winds or currents."@en ;
+                dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                dcterms:created "2019-12-10T08:45:12-08:00Z"^^xsd:dateTimeStamp ;
+                dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001517> ;
+              ] .
 
 
 ###  http://sweetontology.net/realmCryo/FastIce
 soreac:FastIce rdf:type owl:Class ;
              rdfs:subClassOf soreac:SeaIce ;
-             rdfs:label "fast ice"@en .
-
+             rdfs:label "fast ice"@en ;
+             skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001522> ;
+             rdfs:comment "Fast ice is central to the livelihoods of Arctic coastal communities who use it to access fishing and hunting grounds. Vertical fluctuations may be observed during changes of sea level. Fast ice may be formed on site from sea water or by freezing of pack ice of any age to the shore, and it may extend a few yards (meters) or several hundred miles (kilometers) from the coast. Fast ice may be more than one year old and may then be prefixed with appropriate age category (old, second- year, or multiyear). If it is thicker than about 7 ft (2 m) above sea level, it is called an ice shelf."@en ;
+             skos:definition  [
+               rdfs:comment  "A mass of sea ice which 1) is less than 2 meters in thickness and 2) forms along the coast, where it is attached to the shore, to an ice wall, to an ice front, or between shoals or grounded icebergs."@en ;
+               dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+               dcterms:created "2019-12-10T08:50:11-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001522> ;
+             ] .
 
 ###  http://sweetontology.net/realmCryo/Floe
 soreac:Floe rdf:type owl:Class ;
           owl:equivalentClass soreac:IceFloe ;
           rdfs:subClassOf soreac:SeaIce ;
-          rdfs:label "floe"@en .
+          rdfs:label "floe"@en ;
+          skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000066> ;
+          skos:definition  [
+            rdfs:comment  "An ice floe which is formed from frozen sea water, and floats upon the surface of a marine water body."@en ;
+            dcterms:source <https://nsidc.org/cryosphere/glossary/term/ice-floe> ;
+            dcterms:created "2019-12-10T08:54:28-08:00Z"^^xsd:dateTimeStamp ;
+            dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+            prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000066> ;
+          ] .
 
 
 ###  http://sweetontology.net/realmCryo/FrazilIce
 soreac:FrazilIce rdf:type owl:Class ;
                rdfs:subClassOf soreac:SeaIce ;
-               rdfs:label "frazil ice"@en .
+               rdfs:label "frazil ice"@en ;
+               skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000046> ;
+               rdfs:comment "Typically 3 to 4 millimeters in diameter. These new ice classes refer to both marine water and fresh water ice. If using this term for annotation, use it in conjunction with another envo term to express whether the ice is in a marine, freshwater, or other system."@en ;
+               skos:definition  [
+                  rdfs:comment  "New ice which is composed frazil which has congealed into a thin sheet."@en ;
+                  dcterms:source <https://nsidc.org/cryosphere/glossary/term/frazil> ;
+                  dcterms:created "2019-12-10T08:57:38-08:00Z"^^xsd:dateTimeStamp ;
+                  dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                  prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000046>;
+                ] .
 
 
 ###  http://sweetontology.net/realmCryo/FrozenGround
@@ -110,7 +188,17 @@ soreac:FrozenGround rdf:type owl:Class ;
                                     owl:onProperty sorel:hasState ;
                                     owl:hasValue sostp:Frozen
                                   ] ;
-                  rdfs:label "frozen ground"@en .
+                  rdfs:label "frozen ground"@en ;
+                  skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001524> ;
+                  rdfs:comment "Perennially and seasonally frozen ground can vary from being partially to extensively frozen depending on the extent of the phase change. It may be described as hard frozen ground, plastic frozen ground, or dry frozen ground, depending on the pore ice and unfrozen water contents and its compressibility under load."@en ;
+                  skos:definition  [
+                    rdfs:comment  "Land which is below the freezing point of water."@en ;
+                    dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                    dcterms:created "2019-12-10T09:00:09-08:00Z"^^xsd:dateTimeStamp ;
+                    dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                    prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001524> ;
+                  ] .
+
 
 
 ###  http://sweetontology.net/realmCryo/GlacialRegion
@@ -122,14 +210,30 @@ soreac:GlacialRegion rdf:type owl:Class ;
 ###  http://sweetontology.net/realmCryo/Glacier
 soreac:Glacier rdf:type owl:Class ;
              rdfs:subClassOf somaw:Ice ;
-             rdfs:label "glacier"@en .
+             rdfs:label "glacier"@en ;
+             skos:exactMatch <http://purl.obolibrary.org/obo/ENVO_00000133> ;
+             skos:definition  [
+               rdfs:comment  "The definition of glacier is highly variable. Two main issues exist: 1) Whether or not a mass of ice must currently show movement to be considered a glacier or not and 2) What is the relationship between ice sheets and glaciers (i.e., which is the parent in a parent/child relationship or whether they are distinct terms)."@en ;
+               dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+               dcterms:created "2019-12-10T09:06:36-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_00000133> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/GlacierTerminus
 soreac:GlacierTerminus rdf:type owl:Class ;
                      owl:equivalentClass soreac:Snout ;
                      rdfs:subClassOf soreac:GlacialRegion ;
-                     rdfs:label "glacier terminus"@en .
+                     rdfs:label "glacier terminus"@en ;
+                     skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001529> ;
+                     skos:definition  [
+                       rdfs:comment  "An ice mass which constitutes that part of a glacier which has the lowest elevation."@en ;
+                       dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                       dcterms:created "2019-12-10T09:09:25-08:00Z"^^xsd:dateTimeStamp ;
+                       dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                       prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001529> ;
+                     ] .
 
 
 ###  http://sweetontology.net/realmCryo/IceBase
@@ -141,7 +245,15 @@ soreac:IceBase rdf:type owl:Class ;
 ###  http://sweetontology.net/realmCryo/IceCap
 soreac:IceCap rdf:type owl:Class ;
             rdfs:subClassOf sorea:PlanetaryRealm ;
-            rdfs:label "ice cap"@en .
+            rdfs:label "ice cap"@en ;
+            skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000145> ;
+            skos:definition  [
+              rdfs:comment  "A dome-shaped ice mass that covers less than 50,000 km2 of land area (usually covering a highland area)."@en ;
+              dcterms:source <https://en.wikipedia.org/wiki/Ice_cap> ;
+              dcterms:created "2019-12-10T09:12:52-08:00Z"^^xsd:dateTimeStamp ;
+              dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+              prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_00000145> ;
+            ] .
 
 
 ###  http://sweetontology.net/realmCryo/IceCore
@@ -151,30 +263,71 @@ soreac:IceCore rdf:type owl:Class ;
                                owl:onProperty sorelsp:inside ;
                                owl:someValuesFrom somaw:Ice
                              ] ;
-             rdfs:label "ice core"@en .
+             rdfs:label "ice core"@en ;
+             rdfs:comment "The composition of an ice core can be used to reconstruct past climates and climate change; typically removed from an ice sheet (Antarctica and Greenland) or from high mountain glaciers elsewhere."@en ;
+             skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001530> ;
+             skos:definition  [
+               rdfs:comment  "An ice mass which has been drilled from an accumulation of snow and ice that has built up over many years and that has recrystallized and has trapped air bubbles from previous time periods."@en ;
+               dcterms:source <https://orcid.org/0000-0003-4808-4736>  ;
+               dcterms:created "2019-12-13T13:58:24-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001530> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/IceField
 soreac:IceField rdf:type owl:Class ;
               rdfs:subClassOf soreac:SeaIce ;
-              rdfs:label "ice field"@en .
-
+              rdfs:label "ice field"@en ;
+              skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001531> ;
+              skos:definition  [
+                rdfs:comment  "An ice field which is primarily composoed of sea ice floes greater than 10 kilometers across."@en ;
+                dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                dcterms:created "2019-12-13T14:02:20-08:00Z"^^xsd:dateTimeStamp ;
+                dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001531> ;
+              ] .
 
 ###  http://sweetontology.net/realmCryo/IceFloe
 soreac:IceFloe rdf:type owl:Class ;
-             rdfs:label "ice floe"@en .
+             rdfs:label "ice floe"@en ;
+             skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000066> ;
+             skos:definition  [
+               rdfs:comment  "An ice floe which is formed from frozen sea water, and floats upon the surface of a marine water body."@en ;
+               dcterms:source <https://nsidc.org/cryosphere/glossary/term/ice-floe> ;
+               dcterms:created "2019-12-10T08:54:28-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000066> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/IceSheet
 soreac:IceSheet rdf:type owl:Class ;
               rdfs:subClassOf soreac:Glacier ;
-              rdfs:label "ice sheet"@en .
+              rdfs:label "ice sheet"@en ;
+              skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000132> ;
+              skos:definition  [
+                rdfs:comment  "A mass of glacier ice that covers surrounding terrain and is greater than 50,000 km2."@en ;
+                dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                dcterms:created "2020-02-12T12:45:11-08:00Z"^^xsd:dateTimeStamp ;
+                dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_00000132> ;
+              ] .
 
 
 ###  http://sweetontology.net/realmCryo/IceShelf
 soreac:IceShelf rdf:type owl:Class ;
               rdfs:subClassOf somaw:Ice ;
-              rdfs:label "ice shelf"@en .
+              rdfs:label "ice shelf"@en ;
+              skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000380> ;
+              rdfs:comment "An ice shelf may grow hundreds of miles out to sea.  Usually of great horizontal extent and with a level or gently undulating surface. Nourished by annual snow accumulation and also by the seaward extension of land glaciers. Limited areas may be aground. Ice shelves are much thicker than sea ice often filling embayments in the coastline of an ice sheet.. Currently, nearly all ice shelves are in Antarctica, where most of the ice discharged into the ocean flows via ice shelves. The mass balance of an ice shelf may have significant components of both gain and loss at the base. The seaward edge is termed an ice front.  The calving of an ice shelf forms tabular icebergs and ice islands."@en ;
+              skos:definition  [
+                rdfs:comment  "An ice mass which 1) is attached to the coast 2) at least 2 meters in thickness 3) forms where a glacier or ice mass flows down to a coastline and onto the ocean surface and 4) grows by annual snow accumulation or by the seaward extension of land glaciers."@en ;
+                dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                dcterms:created "2020-02-12T12:52:35-08:00Z"^^xsd:dateTimeStamp ;
+                dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_00000380> ;
+              ] .
 
 
 ###  http://sweetontology.net/realmCryo/IceSnowInterface
@@ -192,7 +345,15 @@ soreac:IceStream rdf:type owl:Class ;
 ###  http://sweetontology.net/realmCryo/IceSurface
 soreac:IceSurface rdf:type owl:Class ;
                 rdfs:subClassOf sorea:PlanetaryBoundary ;
-                rdfs:label "ice surface"@en .
+                rdfs:label "ice surface"@en ;
+                skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001545> ;
+                skos:definition  [
+                  rdfs:comment  "A two-dimensional fiat ice surface which is composed primarily of water ice."@en ;
+                  dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                  dcterms:created "2020-02-12T13:05:30-08:00Z"^^xsd:dateTimeStamp ;
+                  dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                  prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001545> ;
+                ] .
 
 
 ###  http://sweetontology.net/realmCryo/Iceberg
@@ -202,7 +363,16 @@ soreac:Iceberg rdf:type owl:Class ;
                                owl:onProperty sorel:hasRealm ;
                                owl:someValuesFrom sorea:Ocean
                              ] ;
-             rdfs:label "iceberg"@en .
+             rdfs:label "iceberg"@en ;
+             skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001546> ;
+             rdfs:comment "The greater part of an iceberg's mass (4/5 to 8/9) is below sea level, which makes them dangerous to shipping in high and mid-latitude regions of the ocean. The top of an ice berg usually protrudes more than 5 m above water-level and typically extends from tens of meters to many tens of kilometres across. Icebergs may be described as tabular, dome-shaped, sloping, pinnacled, dry-docked, blocky, weathered or glacier bergs in addition to having a size qualifier. Icebergs are not sea ice, when they melt they add fresh water to the ocean.  The unmodified term iceberg usually refers to the irregular masses of ice formed by the calving of glaciers along an orographically rough coast, whereas tabular icebergs and ice islands are calved from an ice shelf, while bergs formed from sea ice are called floebergs. In decreasing size, they are classified as: ice island (few thousand square meters to 500 km^2 in area); tabular iceberg; iceberg; bergy bit (less than 5 m above sea level, between 1 and 200 m^2 in area); and growler (less than 1 m above sea level, about 20 m^2 in area). Alaskan icebergs rarely exceed 500 feet in maximum dimension.  Antarctic icebergs originate from the ice mass of the Antarctic continent that has accumulated over many thousands of years."@en ;
+             skos:definition  [
+               rdfs:comment  "An ice mass which has broken away from a larger ice mass on land, such as a glacier or ice shelf, and may be either afloat or aground."@en ;
+               dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+               dcterms:created "2020-02-12T13:16:09-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001546> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/LandIce
@@ -212,19 +382,46 @@ soreac:LandIce rdf:type owl:Class ;
                                owl:onProperty sorel:hasRealm ;
                                owl:someValuesFrom sorea:Land
                              ] ;
-             rdfs:label "land ice"@en .
+             rdfs:label "land ice"@en ;
+             skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001547> ;
+             rdfs:comment "Land ice is any part of the Earth's seasonal or perennial ice cover that has formed over land as the result, principally, of the freezing of precipitation; opposed to sea ice formed by the freezing of seawater.  Thus, an iceberg or tabular iceberg is land ice as well as its parent glacier, ice sheet, or ice shelf. The two major concentrations of land ice are the ice sheets of Greenland and Antarctica. Glaciers and ice caps are the other important forms; however, some members of the glaciology community hold that glaciers (i.e. rock glaciers) need not have any ice."@en ;
+             skos:definition  [
+               rdfs:comment  "An ice mass which has formed over land."@en ;
+               dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+               dcterms:created "2020-02-12T13:18:57-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001547> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/Lead
 soreac:Lead rdf:type owl:Class ;
           rdfs:subClassOf soreac:SeaIce ;
-          rdfs:label "lead"@en .
+          rdfs:label "lead"@en ;
+          skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001551> ;
+          rdfs:comment "Generally, leads are wide enough (and deep enough) for navigation by surface vessels. The term is generally applied to linear features. If the open area is very large it may be called a polynya, although the application of these terms is under debate."@en ;
+          skos:definition  [
+            rdfs:comment  "A surface layer of a water body which has been formed as the result of surface ice fracturing and moving apart."@en ;
+            dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+            dcterms:created "2020-02-12T13:21:01-08:00Z"^^xsd:dateTimeStamp ;
+            dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+            prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001551> ;
+          ] .
 
 
 ###  http://sweetontology.net/realmCryo/PackIce
 soreac:PackIce rdf:type owl:Class ;
              rdfs:subClassOf soreac:DriftIce ;
-             rdfs:label "pack ice"@en .
+             rdfs:label "pack ice"@en ;
+             skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001556> ;
+             rdfs:comment "Has related synonym drift ice. Prior to approximately 2014, pack ice was used for all ranges of drift ice concentrations, thus the terms were in close synonymy." ;
+             skos:definition  [
+               rdfs:comment  "A drift ice mass which has an ice concentration above or equal to 7/10: which covers 70% or more of a given area of a water body."@en ;
+               dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+               dcterms:created "2020-02-12T13:39:40-08:00Z"^^xsd:dateTimeStamp ;
+               dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+               prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001556> ;
+             ] .
 
 
 ###  http://sweetontology.net/realmCryo/SeaIce
@@ -234,24 +431,59 @@ soreac:SeaIce rdf:type owl:Class ;
                               owl:onProperty sorel:hasRealm ;
                               owl:someValuesFrom sorea:Ocean
                             ] ;
-            rdfs:label "sea ice"@en .
+            rdfs:label "sea ice"@en ;
+            skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00002200> ;
+            rdfs:comment "In the United States, NOAA sea ice operations does not include superstructure icing as being sea ice. In sea ice operations however, sea ice is any form of ice found at sea which has originated from the freezing of sea water. It presents the main kind of floating ice encountered at sea. Except where it forms ridges, sea ice is up to a few metres thick, in which respect it differs from shelf ice.  Sea ice may be discontinuous pieces (ice floes) moved on the ocean surface by wind and currents (pack ice), or a motionless sheet attached to the coast (land-fast ice). In brief, it forms first as lolly ice (frazil crystals), thickens into sludge, and coagulates into sheet ice, pancake ice, or into floes of various shapes and sizes. Thereafter, sea ice may develop into pack ice and/or become a form of pressure ice.  Sea ice less than one year old is called first-year ice. Perennial ice is sea ice that survives at least one summer. It may be subdivided into second-year ice and multi-year ice, where multiyear ice has survived at least two summers."@en ;
+            skos:definition  [
+              rdfs:comment  "Water ice which has formed by the freezing of sea water."@en ;
+              dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+              dcterms:created "2020-02-12T13:43:39-08:00Z"^^xsd:dateTimeStamp ;
+              dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+              prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_00002200> ;
+            ] .
 
 
 ###  http://sweetontology.net/realmCryo/SeasonalIce
 soreac:SeasonalIce rdf:type owl:Class ;
                  rdfs:subClassOf soreac:SeaIce ;
-                 rdfs:label "seasonal ice"@en .
+                 rdfs:label "seasonal ice"@en ;
+                 skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_03000071> ;
+                 rdfs:comment "Sea ice develops from young ice; thickness from 0.3 to 2 meters (1 to 6.6 feet).  Sea ice be subdivided into thin first-year ice (white ice), medium first-year ice, and thick first-year ice.  First-year ice is distinguished from older ice primarily by having a higher salinity. Undeformed first-year ice differs from older ice in that it is smoother and lacks refrozen melt ponds. Characteristically level where undisturbed by pressure, but where ridges occur, they  distinguished by being larger, more angular, and more porous than multiyear ridges."@en ;
+                 skos:definition  [
+                   rdfs:comment  "Sea ice which has formed over a single freezing season."@en ;
+                   dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                   dcterms:created "2020-02-12T13:45:28-08:00Z"^^xsd:dateTimeStamp ;
+                   dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                   prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_03000071> ;
+                 ] .
 
 
 ###  http://sweetontology.net/realmCryo/Snout
 soreac:Snout rdf:type owl:Class ;
-           rdfs:label "snout"@en .
+           rdfs:label "snout"@en ;
+           skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001529> ;
+           skos:definition  [
+             rdfs:comment  "An ice mass which constitutes that part of a glacier which has the lowest elevation."@en ;
+             dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+             dcterms:created "2020-02-12T13:48:09-08:00Z"^^xsd:dateTimeStamp ;
+             dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+             prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001529> ;
+           ] .
 
 
 ###  http://sweetontology.net/realmCryo/TabularIceberg
 soreac:TabularIceberg rdf:type owl:Class ;
                     rdfs:subClassOf soreac:Iceberg ;
-                    rdfs:label "tabular iceberg"@en .
+                    rdfs:label "tabular iceberg"@en ;
+                    skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_01001534> ;
+                    rdfs:comment "Newly formed tabular icebergs have nearly vertical sides and flat tops. In the Antarctic, they may be tens of kilometers wide, up to 160 km (100 miles) long, and as much as 300 m (1000 ft) thick, with about 30 m (100 ft) exposed above the sea surface. In the Arctic, large icebergs of this type are called ice islands, but they are considerably smaller than the largest of the antarctic variety. Has synonyms tabular berg, table iceberg. Formerly called barrier iceberg."@en ;
+                    skos:definition  [
+                      rdfs:comment  "An iceberg which 1) has a flat upper surface, 2) is derived from an ice shelf, ice tongue, or floating tidewater glacier via detachment."@en ;
+                      dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+                      dcterms:created "2020-02-12T13:50:16-08:00Z"^^xsd:dateTimeStamp ;
+                      dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+                      prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_01001534> ;
+                    ] .
 
 
 ###  http://sweetontology.net/realmCryo/Tundra
@@ -261,7 +493,15 @@ soreac:Tundra rdf:type owl:Class ;
                               owl:onProperty sorel:hasRealm ;
                               owl:someValuesFrom soreac:FrozenGround
                             ] ;
-            rdfs:label "tundra"@en .
+            rdfs:label "tundra"@en ;
+            skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000112> ;
+            skos:definition  [
+              rdfs:comment  "A vegetated area which is part of a tundra ecosystem."@en ;
+              dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
+              dcterms:created "2020-02-12T13:52:08-08:00Z"^^xsd:dateTimeStamp ;
+              dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;
+              prov:wasDerivedFrom <http://purl.obolibrary.org/obo/ENVO_00000112> ;
+            ] .
 
 
 #################################################################

--- a/src/realmCryo.ttl
+++ b/src/realmCryo.ttl
@@ -306,7 +306,7 @@ soreac:IceSheet rdf:type owl:Class ;
               rdfs:label "ice sheet"@en ;
               skos:closeMatch <http://purl.obolibrary.org/obo/ENVO_00000132> ;
               skos:definition  [
-                rdfs:comment  "A mass of glacier ice that covers surrounding terrain and is greater than 50,000 km2."@en ;
+                rdfs:comment  "A glacier which covers an area of greater than 50,000 square kilometers."@en ;
                 dcterms:source <https://orcid.org/0000-0003-4808-4736> ;
                 dcterms:created "2020-02-12T12:45:11-08:00Z"^^xsd:dateTimeStamp ;
                 dcterms:creator <https://orcid.org/0000-0003-4091-6059> ;


### PR DESCRIPTION
Adding back progress from ESIP harmonization cluster efforts on creating definitions for the cryosphere terms. Crossrefs to from SWEET to ENVO terms added during the harmonization captured using skos:closeMatch and a prov:wasDerived from in the definition. Additional provenance added by rdfs:seeAlso to GitHub issue where the discussion was documented. Additional discussion is needed to create a graph fragment for a prov:Activity in some namespace that corresponds to the ESIP harmonization cluster effort to capture the provenance of additions of definitions to SWEET. There were no axiom changes to realmCryo.ttl, but axiom changes were needed for phenCryo.ttl to reconcile the definition with existing SWEET axioms. Periglacial was changed to be a subclass of PhysicalProcess since it is not a Glacial Process. Periglaciation needs more discussion since the term does not occur in any community of practice references. It was changed to match Periglaciation axiomatization, ENVO created it as a synonym of Periglacial. 