### PR TITLE
initial mapping of SWEET realms to GCMD science keywords

### DIFF
--- a/alignments/sweet-gcmd-mapping.ttl
+++ b/alignments/sweet-gcmd-mapping.ttl
@@ -1,0 +1,529 @@
+# baseURI: http://sweetontology.net/alignment/gcmd
+# imports: https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords
+# imports: http://www.w3.org/1999/02/22-rdf-syntax-ns
+# imports: http://www.w3.org/2000/01/rdf-schema
+# imports: http://www.w3.org/2001/XMLSchema
+# imports: http://www.w3.org/2002/07/owl
+# imports: http://www.w3.org/2004/02/skos/core
+# imports: http://www.w3.org/2006/time
+# imports: http://www.w3.org/ns/dcat
+# imports: http://www.w3.org/ns/org
+# imports: http://www.w3.org/ns/prov
+# imports: http://xmlns.com/foaf/0.1/
+# imports: http://sweetontology.net/realm/
+# imports: http://sweetontology.net/realmAstroStar/
+# imports: http://sweetontology.net/realmAtmo/
+# imports: http://sweetontology.net/realmBiolBiome/
+# imports: http://sweetontology.net/realmCryo/
+# imports: http://sweetontology.net/realmGeol/
+# imports: http://sweetontology.net/realmGeolBasin/
+# imports: http://sweetontology.net/realmGeolConstituent/
+# imports: http://sweetontology.net/realmGeolContinental/
+# imports: http://sweetontology.net/realmHydro/
+# imports: http://sweetontology.net/realmHydroBody/
+# imports: http://sweetontology.net/realmLandAeolian/
+# imports: http://sweetontology.net/realmLandCoastal/
+# imports: http://sweetontology.net/realmLandFluvial/
+# imports: http://sweetontology.net/realmLandGlacial/
+# imports: http://sweetontology.net/realmLandOrographic/
+# imports: http://sweetontology.net/realmLandProtected/
+# imports: http://sweetontology.net/realmLandTectonic/
+# imports: http://sweetontology.net/realmLandVolcanic/
+# imports: http://sweetontology.net/realmLandform/
+# imports: http://sweetontology.net/realmOcean/
+# imports: http://sweetontology.net/realmOceanFloor/
+# imports: http://sweetontology.net/realmSoil/
+
+@prefix : <http://sweetontology.net/alignment/gcmd> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix organization: <http://www.w3.org/ns/org#> .
+@prefix dct: <http://purl.org/dc/dcmitype/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix gcmd: <https://gcmd.earthdata.nasa.gov/kms/concept/> .
+@prefix soall: <http://sweetontology.net/sweetAll/> .
+@prefix sorea: <http://sweetontology.net/realm/> .
+@prefix soreaas: <http://sweetontology.net/realmAstroStar/> .
+@prefix soreaa: <http://sweetontology.net/realmAtmo/> .
+@prefix soreabb: <http://sweetontology.net/realmBiolBiome/> .
+@prefix soreac: <http://sweetontology.net/realmCryo/> .
+@prefix soreag: <http://sweetontology.net/realmGeol/> .
+@prefix soreagb: <http://sweetontology.net/realmGeolBasin/> .
+@prefix soreagcons: <http://sweetontology.net/realmGeolConstituent/> .
+@prefix soreagcont: <http://sweetontology.net/realmGeolContinental/> .
+@prefix soreah: <http://sweetontology.net/realmHydro/> .
+@prefix soreahb: <http://sweetontology.net/realmHydroBody/> .
+@prefix soreala: <http://sweetontology.net/realmLandAeolian/> .
+@prefix sorealc: <http://sweetontology.net/realmLandCoastal/> .
+@prefix sorealf: <http://sweetontology.net/realmLandFluvial/> .
+@prefix sorealg: <http://sweetontology.net/realmLandGlacial/> .
+@prefix sorealo: <http://sweetontology.net/realmLandOrographic/> .
+@prefix sorealp: <http://sweetontology.net/realmLandProtected/> .
+@prefix sorealt: <http://sweetontology.net/realmLandTectonic/> .
+@prefix sorealv: <http://sweetontology.net/realmLandVolcanic/> .
+@prefix soreal: <http://sweetontology.net/realmLandform/> .
+@prefix soreao: <http://sweetontology.net/realmOcean/> .
+@prefix soreaofl: <http://sweetontology.net/realmOceanFloor/> .
+@prefix soreas: <http://sweetontology.net/realmSoil/> .
+@prefix sweet: <http://sweetontology.net/> .
+@base <http://sweetontology.net/alignment/gcmd> .
+
+<http://sweetontology.net/alignment/gcmd>
+  rdf:type owl:Ontology ;
+  dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+  dcterms:created "2020-08-13"^^xsd:date ;
+  dcterms:creator [
+      a foaf:Person ;
+      organization:memberOf <https://ror.org/02p9cyn66> ;
+      foaf:family_name "Whitehead" ;
+      foaf:firstName "Brandon" ;
+      foaf:mbox <mailto:whiteheadb@landcareresearch.co.nz> ;
+      foaf:name "Brandon Whitehead" ;
+      foaf:publications <http://orcid.org/0000-0002-0337-8610> ;
+    ] ;
+  voaf:reliesOn <http://sweetontology.net/sweetAll> ;
+  voaf:reliesOn gcmd: ;
+  rdfs:comment "A preliminary mapping of SWEET concepts with the Global Change Master Directory (GCMD) Science Keywords"@en ;
+  rdfs:label "SWEET-GCMD mapping graph" ;
+  owl:imports <http://purl.org/vocommons/voaf> ;
+  owl:imports <http://sweetontology.net/sweetAll> ;
+  owl:imports <http://www.w3.org/2004/02/skos/core> ;
+  owl:imports <http://www.w3.org/2006/time> ;
+  owl:imports <http://www.w3.org/ns/org> ;
+  owl:imports <https://gcmd.earthdata.nasa.gov/kms/concepts/concept_scheme/sciencekeywords> ;
+  owl:imports <http://xmlns.com/foaf/0.1/> ;
+ .
+
+gcmd:2e544263-d92f-46c2-9568-25e36d0b9825
+    skos:exactMatch soreas:ActiveLayer .
+gcmd:10270ee0-8d85-4c75-9fa2-49e7a9755cb3
+    skos:exactMatch soreas:ActiveLayer .
+gcmd:0cd7a96f-46e1-4d86-93d0-9cbb6fda61e3
+    skos:exactMatch soreas:Cryosol .
+gcmd:1469f30b-6eb4-4186-b1ef-7dd25c34c592
+    skos:exactMatch soreas:Cryosol .
+gcmd:83cf51f6-8c03-4f6d-b605-fde9818c7805
+    skos:exactMatch soreas:OrganicMatter .
+gcmd:215f69b9-259a-4b82-9f8f-f96d4f5aaad2
+    skos:exactMatch soreas:OrganicMatter .
+gcmd:ee92daf8-d0da-4476-b389-0485114cbbe9
+    skos:exactMatch soreas:OrganicMatter .
+gcmd:e82c0632-5a3c-4da2-ba10-55c0fc222580
+    skos:exactMatch soreas:OrganicMatter .
+gcmd:4fe601b0-314f-4f63-8ec1-3b96cc7263b8
+    skos:exactMatch soreas:Paleosol .
+gcmd:b54e01eb-02d9-413a-baf1-40a6e59d9eae
+    skos:exactMatch soreas:Paleosol .
+gcmd:fb3ce3be-d830-407f-bd7c-58d66c24b6be
+    skos:exactMatch soreas:Permafrost .
+gcmd:c82f3480-545f-4491-83f1-0477369ddcd8
+    skos:exactMatch soreas:Permafrost .
+gcmd:1f4cdbc4-0f65-4384-83c9-9422c280717d
+    skos:exactMatch soreas:Permafrost .
+gcmd:b6723314-3db7-4bdd-85ee-0b8507e6ae1b
+    skos:exactMatch soreas:Permafrost .
+gcmd:08240c92-00b5-4f25-bf2e-8030531a78d2
+    skos:exactMatch soreas:Permafrost .
+gcmd:6a7eed90-327a-4609-b952-c9617445a1d1
+    skos:exactMatch soreas:Permafrost .
+gcmd:78e5e44c-7832-456d-a599-893ea87ae695
+    skos:exactMatch soreas:Talik .
+gcmd:c39710ae-423f-44c8-b969-9af8a1f912cf
+    skos:exactMatch soreas:Talik .
+gcmd:290354cc-c670-4845-bb66-ef1974b1e2a2
+    skos:exactMatch soreaofl:ColdSeep .
+gcmd:b677862b-7921-458f-a6db-0eb46469df33
+    skos:exactMatch soreaofl:HydrothermalVent .
+gcmd:bee69b66-3921-4883-920f-6a0bd85b614f
+    skos:exactMatch soreaofl:HydrothermalVent .
+gcmd:f345294c-36e6-4c76-b484-2204cc0bc3a2
+    skos:exactMatch soreaofl:MidOceanRidge .
+gcmd:367718c8-cc3b-4c94-a270-0a278afabb43
+    skos:exactMatch soreaofl:Reef .
+gcmd:83520258-413c-4842-93c0-58a23dc58638
+    skos:exactMatch soreaofl:Seamount .
+gcmd:18ce5577-26e9-4b76-860b-1ba31cafa9d0
+    skos:exactMatch soreaofl:SubmarineCanyon .
+gcmd:1c286cb7-2668-4db3-a5ac-cb8b710bebc2
+    skos:exactMatch soreao:Abyssal .
+gcmd:04305c55-14f0-42a3-a099-79eb326946d7
+    skos:exactMatch soreao:Halocline .
+gcmd:eb958dfb-5e38-401f-8b42-5f1273c75a4a
+    skos:exactMatch soreao:NeriticZone .
+gcmd:70acf223-7895-4cbe-aca6-815babb2b7ed
+    skos:exactMatch soreao:Polynya .
+gcmd:10a128a6-12d4-4bce-b25d-2ffc464182f4
+    skos:exactMatch soreao:Polynya .
+gcmd:2ad73f85-8bad-4e5a-a902-e83eee910b5e
+    skos:exactMatch soreao:Pycnocline .
+gcmd:68772b70-e493-48d5-b063-00b9d2dd4078
+    skos:exactMatch soreao:Thermocline .
+gcmd:5d9d1d85-b402-4f84-ab5c-03a49fc68c25
+    skos:exactMatch sorealv:Caldera .
+gcmd:1a0e7a60-9c22-40c5-8424-55119b4db743
+    skos:exactMatch sorealv:Caldera .
+gcmd:ea580c65-2f66-4745-bbb6-dde61279ecfa
+    skos:exactMatch sorealv:Geyser .
+gcmd:1a888a27-8715-46c8-9e11-a6bffba00078
+    skos:exactMatch sorealv:Geyser .
+gcmd:edb9d13d-27a1-4e9a-a32e-4e49b5e76836
+    skos:exactMatch sorealv:LavaPlain .
+gcmd:dc18db4d-2184-453e-ba0a-86c83a9bede0
+    skos:exactMatch sorealv:LavaPlain .
+gcmd:cefe2205-809c-4386-915e-a8737ae8e68e
+    skos:exactMatch sorealv:Volcano .
+gcmd:7c2e1960-ae20-46a9-acf1-a3e71542fbb4
+    skos:exactMatch sorealv:Volcano .
+gcmd:58c12630-a889-44c1-a951-56bbbe9758c9
+    skos:exactMatch sorealt:FractureZone .
+gcmd:ca874a66-f3a8-4099-978c-4684944dc348
+    skos:exactMatch sorealt:RiftValley .
+gcmd:0bd4d492-4911-4a6a-afaa-34899a80294b
+    skos:exactMatch sorealt:RiftValley .
+gcmd:46172bbe-8bf0-49a0-848f-129c089aeb8e
+    skos:exactMatch sorealt:TectonicLandform .
+gcmd:2b1f7993-2d54-40de-abc4-3909f619ad4e
+    skos:exactMatch sorealp:Park .
+gcmd:c34ea556-10bd-4665-9f22-68b5d05c9aea
+    skos:exactMatch sorealo:Mountain .
+gcmd:8b7f66ea-d481-4641-9dbf-da90ca3ad9c9
+    skos:exactMatch sorealo:Mountain .
+gcmd:694e18ec-ceaf-4070-9763-f3ee6dbd6b5b
+    skos:exactMatch sorealo:Plateau .
+gcmd:0baf564f-f942-4aeb-9b75-30b838f28f3f
+    skos:exactMatch sorealo:Plateau .
+gcmd:ca091be1-4762-49ec-859b-a1a2fcb8e038
+    skos:exactMatch sorealo:Ridge .
+gcmd:97298feb-6991-4d68-8337-177460e436ad
+    skos:exactMatch sorealo:Ridge .
+gcmd:d37d51e0-1bef-473a-9221-6713166762f9
+    skos:exactMatch sorealg:Arete .
+gcmd:8e73bff6-c2f9-46a6-963b-8ef09dd7f5f3
+    skos:exactMatch sorealg:Arete .
+gcmd:5e012809-98cf-468f-bdf7-7cea8569d3ab
+    skos:exactMatch sorealg:Esker .
+gcmd:158a8764-a6e4-4d28-a1b9-b2ab91e09995
+    skos:exactMatch sorealg:Esker .
+gcmd:3c78951a-0293-4fb0-baff-ec7372fe784d
+    skos:exactMatch sorealg:GlacialLandform .
+gcmd:b895f4b5-5273-49ef-883f-b67d9f199505
+    skos:exactMatch sorealg:GlacialLandform .
+gcmd:4f590d94-110c-4762-9171-aba6d24af6a0
+    skos:exactMatch sorealg:Moraine .
+gcmd:2575cfaf-1a09-48b6-acb9-fda23b6f4719
+    skos:exactMatch sorealg:Moraine .
+gcmd:b1ce822a-139b-4e11-8bbe-453f19501c36
+    skos:exactMatch sorealg:RockGlacier .
+gcmd:ee2af62b-9f76-440c-aa9b-77940468b8f4
+    skos:exactMatch sorealg:RockGlacier .
+gcmd:fcbf8f96-ac53-41b6-9c98-a87425a4ec82
+    skos:exactMatch sorealg:RockGlacier .
+gcmd:2d98cbaf-8c82-46e6-9962-a5e63918fe66
+    skos:exactMatch sorealg:RockGlacier .
+gcmd:bffac466-83aa-4060-a378-6d2d6e49f2a1
+    skos:exactMatch sorealg:TillPlain .
+gcmd:2bea72da-2cf3-403c-adb9-9d963eb71536
+    skos:exactMatch sorealg:TillPlain .
+gcmd:6a426480-c58f-4b6b-8e35-0975b7f6edb5
+    skos:exactMatch soreal:LandSurface .
+gcmd:f36d71c6-f2ad-49c4-809f-09b4f0688412
+    skos:exactMatch soreal:Landscape .
+gcmd:e25ce36c-eacd-447a-9d73-ccc8a7e3a328
+    skos:exactMatch sorealf:Canyon .
+gcmd:a78c946a-9529-4643-b002-1aa2ac9cfed6
+    skos:exactMatch sorealf:Canyon .
+gcmd:272700c5-d762-452b-8e9f-130e3a51efb5
+    skos:exactMatch sorealf:DrainageBasin .
+gcmd:d71f94cb-e773-487a-a8ff-9c5f11c1dbc4
+    skos:exactMatch sorealf:FloodPlain .
+gcmd:ba37314d-ec38-4e67-bf30-7e1fdc6bfbad
+    skos:exactMatch sorealf:FloodPlain .
+gcmd:cb5193ab-2d7a-4b35-b7ec-f16ce78ae270
+    skos:exactMatch sorealf:FluvialLandform .
+gcmd:bdc0bd86-a3a3-48fa-b1fb-4ca5d13d4dde
+    skos:exactMatch sorealf:FluvialLandform .
+gcmd:b9b85df8-3b95-4baf-bd32-8bacd35dc9b5
+    skos:exactMatch sorealf:Gully .
+gcmd:2f8ad9b0-adb8-4022-8c95-bca68e7a87a5
+    skos:exactMatch sorealf:Gully .
+gcmd:ac2d1035-1896-42c1-861b-042a917b6889
+    skos:exactMatch sorealf:KarstLandform .
+gcmd:590aa85e-bbce-40b2-8ffb-53d80a61c51a
+    skos:exactMatch sorealf:KarstLandform .
+gcmd:8ca51b5e-0b7a-4b7a-b7e2-6e163e195e26
+    skos:exactMatch sorealf:LacustrinePlain .
+gcmd:588d868d-05a4-4dac-9fb3-770b54ce39e5
+    skos:exactMatch sorealf:LacustrinePlain .
+gcmd:cae41424-161f-4378-a1a4-62cd76c61143
+    skos:exactMatch sorealf:Ripple .
+gcmd:1376f8a1-84f2-4797-a978-69ec520e2423
+    skos:exactMatch sorealf:Ripple .
+gcmd:f4f9c238-2d7e-4529-944b-52389c13932c
+    skos:exactMatch sorealf:Valley .
+gcmd:87b01c3a-f64f-4764-8cb8-c40ebcd5a989
+    skos:exactMatch sorealf:Valley .
+gcmd:ff850d62-675c-4386-a375-fe4af92ec3ff
+    skos:exactMatch sorealc:Bar .
+gcmd:6c061296-2c92-4aa4-b9d1-6ecf0efde876
+    skos:exactMatch sorealc:Bar .
+gcmd:7e28f2e0-a641-4085-be07-366ed6e701f4
+    skos:exactMatch sorealc:BarrierIsland .
+gcmd:6e3135e9-6be6-4995-a5df-022f6a0cf45b
+    skos:exactMatch sorealc:BarrierIsland .
+gcmd:128db882-0522-4a5e-ac69-81d05986a645
+    skos:exactMatch sorealc:BarrierIsland .
+gcmd:47be68db-d10d-43e7-b150-61cfd3f06126
+    skos:exactMatch sorealc:Coastal .
+gcmd:c58320e6-3f1d-4c36-9bee-6bad73404c21
+    skos:exactMatch sorealc:CoastalLandform .
+gcmd:0cff6e4b-e42a-4565-89ff-350adf41ed69
+    skos:exactMatch sorealc:CoastalLandform .
+gcmd:f9f0f92b-7901-4dda-8d64-be4e845ce29b
+    skos:exactMatch sorealc:Delta .
+gcmd:daa297ec-4397-4caa-b563-634a71f62b8a
+    skos:exactMatch sorealc:Delta .
+gcmd:b37b1bdf-6392-4a80-891a-14f177ba2ca2
+    skos:exactMatch sorealc:Delta .
+gcmd:ad535c83-3b93-4632-8aaa-7dfba8bb125a
+    skos:exactMatch sorealc:Delta .
+gcmd:93647a7c-a881-4066-a696-c19053c7c30b
+    skos:exactMatch sorealc:Delta .
+gcmd:82b62e59-6ea1-48e1-a402-bd386c5046eb
+    skos:exactMatch sorealc:IntertidalZone .
+gcmd:fa3c6df8-a1e1-41d5-9de1-49b92e1ea455
+    skos:exactMatch sorealc:Island .
+gcmd:9d078d5c-62cb-46b5-a6f5-43678643a0ce
+    skos:exactMatch sorealc:Island .
+gcmd:74caea9b-6023-438b-af3d-bb9d948036f1
+    skos:exactMatch sorealc:Island .
+gcmd:9bb0de49-1812-400c-a73b-d2686dd9066a
+    skos:exactMatch sorealc:IslandArc .
+gcmd:e069e3fc-0c75-40ee-92d7-595991f8fdb4
+    skos:exactMatch sorealc:Isthmus .
+gcmd:ca9d9064-91c8-4c49-b388-e5f7290a3234
+    skos:exactMatch sorealc:Isthmus .
+gcmd:86987ad2-21d2-496b-9119-350b3fb17455
+    skos:exactMatch sorealc:MudFlat .
+gcmd:771b2919-ab55-4c71-8561-b4fb365da53f
+    skos:exactMatch sorealc:MudFlat .
+gcmd:4c2d2255-680d-47d6-adb2-179093593f8a
+    skos:exactMatch sorealc:Shoal .
+gcmd:cae5bafd-10a7-4bcf-af1a-3e187ee5e955
+    skos:exactMatch sorealc:Shoal .
+gcmd:94b575b8-eac4-433d-aa74-d781b650f452
+    skos:exactMatch sorealc:Shoal .
+gcmd:1d3b4eb7-9931-44bf-8457-26847051b7a8
+    skos:exactMatch sorealc:Shoreline .
+gcmd:57e6b119-567b-44d0-9d93-278ed5c21c47
+    skos:exactMatch sorealc:Shoreline .
+gcmd:4e5cf935-cf17-4947-bd1f-6816a855953a
+    skos:exactMatch sorealc:Shoreline .
+gcmd:320e14a6-4882-4533-b1cf-55d49c8a6b37
+    skos:exactMatch sorealc:Tombolo .
+gcmd:30f556c4-7531-4758-9e51-8adc6b2e0e8a
+    skos:exactMatch sorealc:Tombolo .
+gcmd:26637389-f4f6-47a0-9c3d-17e93ab99dea
+    skos:exactMatch soreala:AeolianLandform .
+gcmd:ed75fb8f-cb96-448e-ada5-dc48fbd0ebb1
+    skos:exactMatch soreala:AeolianLandform .
+gcmd:5d5426f6-e7ce-41c1-a3d3-b93adf748f0f
+    skos:exactMatch soreala:Desert .
+gcmd:dabc0fc5-acac-48df-b32e-02c9166e8385
+    skos:exactMatch soreala:Yardang .
+gcmd:59d1b0f7-ef02-4fa4-8d47-7eda39794713
+    skos:exactMatch soreala:Yardang .
+gcmd:b58fc6f1-2fb5-4e3a-9553-f041fe75960b
+    skos:exactMatch soreahb:Basin .
+gcmd:79c7fd4c-9328-4a6f-82ed-bb012b570ecd
+    skos:exactMatch soreahb:Basin .
+gcmd:a0c33d15-b76c-4a0d-abb7-6919102b2977
+    skos:exactMatch soreahb:Canal .
+gcmd:5a1ebca4-057d-43b9-af6a-04f57b93f8bb
+    skos:exactMatch soreahb:Estuary .
+gcmd:a90899c8-fe50-48e0-b92c-bb64f6ae681c
+    skos:exactMatch soreahb:Fjord .
+gcmd:c9291bc7-784d-486a-95fa-f08fa1edcad9
+    skos:exactMatch soreahb:Fjord .
+gcmd:7299f45f-eafb-4ed9-ae12-5e01c97c1530
+    skos:exactMatch soreahb:Fjord .
+gcmd:6aed82cb-be90-4e58-ae33-14943ea555be
+    skos:exactMatch soreahb:Fjord .
+gcmd:666d9a2b-aaa8-4789-a9d9-a6774e650fe4
+    skos:exactMatch soreahb:Fjord .
+gcmd:f43cd776-c568-4d09-997c-0a8ad1022e06
+    skos:exactMatch soreahb:Inlet .
+gcmd:49db8758-1282-45a0-ad3f-0f1e9d8abc44
+    skos:exactMatch soreahb:Inlet .
+gcmd:356a245d-418a-4560-9eb1-d12f8f155f66
+    skos:exactMatch soreahb:Inlet .
+gcmd:c733c179-c12a-47e9-8e9a-817a5212446f
+    skos:exactMatch soreahb:Lagoon .
+gcmd:879d286b-9ea6-4e4d-bdd1-56a4c7ca1531
+    skos:exactMatch soreahb:Lagoon .
+gcmd:d9483208-ff59-4293-9867-3f4895e58c9f
+    skos:exactMatch soreahb:Lagoon .
+gcmd:081d131a-6bef-47dc-adb3-f96da9123f93
+    skos:exactMatch soreahb:Lagoon .
+gcmd:88adcca6-2bc8-443a-9f25-c9aded577615
+    skos:exactMatch soreahb:Marsh .
+gcmd:4c09d43f-68d5-469d-aaed-f9ef8968ef2e
+    skos:exactMatch soreahb:Marsh .
+gcmd:b70ef20c-7215-4a39-9479-dbff7c2fdca9
+    skos:exactMatch soreahb:Peatland .
+gcmd:f3b5489d-6723-40bf-bd55-68a0f2fc1874
+    skos:exactMatch soreahb:Peatland .
+gcmd:89228e69-5a64-4662-839f-cb3d2209fa41
+    skos:exactMatch soreahb:Pond .
+gcmd:5f292d99-b14a-4f18-bbe0-8025d04cae50
+    skos:exactMatch soreahb:Pond .
+gcmd:bb6b3b76-c496-464b-bd20-1b22296aae15
+    skos:exactMatch soreahb:River .
+gcmd:87624706-e11f-4043-ac54-479ed94b8dac
+    skos:exactMatch soreahb:River .
+gcmd:c5b85924-9e3f-4106-b389-1ab4486bd233
+    skos:exactMatch soreahb:Sound .
+gcmd:1815faf3-2411-4d2a-a3d5-1e5b0c50782b
+    skos:exactMatch soreahb:Sound .
+gcmd:b498a5cb-f77d-4485-8174-81dec28cee0e
+    skos:exactMatch soreahb:Spring .
+gcmd:620a9e6c-5851-48b7-93c5-a1706546f5d1
+    skos:exactMatch soreahb:Spring .
+gcmd:1d2d0777-b47e-45ee-ac85-2d7b9f6e4ffd
+    skos:exactMatch soreahb:Stream .
+gcmd:01a84bc1-a571-4d23-b57f-1b04fd9542a6
+    skos:exactMatch soreahb:Stream .
+gcmd:6cec3b57-1a7f-404d-afde-4de045ef0dd2
+    skos:exactMatch soreahb:Swamp .
+gcmd:8c05bcf2-d13b-44fd-b1a2-5ec797b2f851
+    skos:exactMatch soreahb:Swamp .
+gcmd:8f6adff6-672d-4066-8c85-25418a7d0e00
+    skos:exactMatch soreahb:Swamp .
+gcmd:4811065d-7aed-45e0-ac31-6417123be10e
+    skos:exactMatch soreahb:Swamp .
+gcmd:b72c49a1-8276-4753-8c88-894bc7bbf60d
+    skos:exactMatch soreahb:Wetland .
+gcmd:7da95c01-4b39-437e-a8d4-fd572e43f693
+    skos:exactMatch soreahb:Wetland .
+gcmd:d138302a-03b3-4cf7-95db-ac98f863c04f
+    skos:exactMatch soreahb:Wetland .
+gcmd:a957363b-2f2c-4169-a656-c2f24933eb72
+    skos:exactMatch soreah:Aquifer .
+gcmd:5debb283-51e4-435e-b2a2-e8e2a977220d
+    skos:exactMatch soreah:SurfaceWater .
+gcmd:ecbe9f17-6012-4e39-a707-713973b7d167
+    skos:exactMatch soreah:WaterTable .
+gcmd:a91a00f7-05ed-4633-9fac-1772a48b6342
+    skos:exactMatch soreagcont:ContinentalMargin .
+gcmd:1ef327e1-6139-49ff-87c3-f959ea75a511
+    skos:exactMatch soreagcons:Corona .
+gcmd:b58fc6f1-2fb5-4e3a-9553-f041fe75960b
+    skos:exactMatch soreagb:Basin .
+gcmd:79c7fd4c-9328-4a6f-82ed-bb012b570ecd
+    skos:exactMatch soreagb:Basin .
+gcmd:2b9ad978-d986-4d63-b477-0f5efc8ace72
+    skos:exactMatch soreag:SolidEarth .
+gcmd:76589134-8d93-4e45-8476-f04497181d14
+    skos:exactMatch soreac:AlpineTundra .
+gcmd:944d9d09-4317-4e9a-9aa5-dc4282be406e
+    skos:exactMatch soreac:AlpineTundra .
+gcmd:376a1d5c-2496-4381-981f-bc047af92044
+    skos:exactMatch soreac:FrozenGround .
+gcmd:8073b62d-a2f3-4ad9-b619-de26f28877a7
+    skos:exactMatch soreac:FrozenGround .
+gcmd:68eed887-8008-4352-b420-949457ab59ab
+    skos:exactMatch soreac:Glacier .
+gcmd:4a426aab-4a95-4bf4-8449-19a72a251541
+    skos:exactMatch soreac:Glacier .
+gcmd:d8e2bcae-7781-41b6-8d2d-7c82ae61be47
+    skos:exactMatch soreac:GlacierTerminus .
+gcmd:84fff9f2-4dad-4ff8-9d10-cacd6a1864fb
+    skos:exactMatch soreac:GlacierTerminus .
+gcmd:4733ef2c-e512-451b-8079-78ff7278e35c
+    skos:exactMatch soreac:IceFloe .
+gcmd:af0d756e-784e-4747-97d0-3425baf5d09b
+    skos:exactMatch soreac:IceFloe .
+gcmd:aa15804c-5f7f-40cc-b949-aa3e4418fc27
+    skos:exactMatch soreac:IceFloe .
+gcmd:10b1872b-4a48-4360-a449-388e8988bca9
+    skos:exactMatch soreac:IceSheet .
+gcmd:b2800856-f1e3-41aa-bdc4-75e9cd626d3f
+    skos:exactMatch soreac:IceSheet .
+gcmd:4d95ccc8-3ef9-40df-85e7-db36cb815499
+    skos:exactMatch soreac:Iceberg .
+gcmd:1efe6ac1-d375-44c3-b8ec-d0ff2987a881
+    skos:exactMatch soreac:Iceberg .
+gcmd:1151dc7e-7441-4a21-95b6-1d03a1053f60
+    skos:exactMatch soreac:Iceberg .
+gcmd:f1c79b5f-fcc2-42e7-818b-7534f79081ff
+    skos:exactMatch soreac:Iceberg .
+gcmd:c79453a3-ed2f-4ec4-9298-bf9fd11d08eb
+    skos:exactMatch soreac:Lead .
+gcmd:6fe420c1-2285-4031-babe-f0243c59a617
+    skos:exactMatch soreac:Lead .
+gcmd:5d7ea074-225b-4221-b122-e6a085cdce24
+    skos:exactMatch soreac:PackIce .
+gcmd:ea85ea0b-1b7d-464a-9f8c-1f80383ffc51
+    skos:exactMatch soreac:PackIce .
+gcmd:a4aea007-d297-4051-8b41-5cdde00b4d1e
+    skos:exactMatch soreac:SeaIce .
+gcmd:860e2af9-ce29-4f3f-b027-ae3747eb3e01
+    skos:exactMatch soreac:SeaIce .
+gcmd:d73e969a-4b66-4713-8d63-fa3cbb1e25e3
+    skos:exactMatch soreac:SeaIce .
+gcmd:c6455081-132d-4661-bb5f-22edf2f90800
+    skos:exactMatch soreabb:AquaticEcosystem .
+gcmd:ad497e7a-48fa-45e1-90a5-b052508bdb30
+    skos:exactMatch soreabb:CoralReef .
+gcmd:fa3bc02d-31a7-4456-b716-a8b8f8393c86
+    skos:exactMatch soreabb:CoralReef .
+gcmd:dff4d4af-e1e0-4991-884b-a1c088a802b2
+    skos:exactMatch soreabb:CoralReef .
+gcmd:c6244bfb-300f-4818-bf45-cf1a15e7e073
+    skos:exactMatch soreabb:CoralReef .
+gcmd:2c74f390-9d82-4903-98e0-bddf0d3247fb
+    skos:exactMatch soreabb:Croplands .
+gcmd:f1a25060-330c-4f84-9633-ed59ae8c64bf
+    skos:exactMatch soreabb:Ecosystem .
+gcmd:46e4aaa4-349c-4049-a910-035391360010
+    skos:exactMatch soreabb:Forest .
+gcmd:ad73e951-fb5b-4a0b-b034-9469a8bfccaa
+    skos:exactMatch soreabb:FreshwaterEcosystem .
+gcmd:142ea0c1-b77f-44da-8c64-ac7ee13fd5f6
+    skos:exactMatch soreabb:Grassland .
+gcmd:f6350232-b1c7-458c-bc43-bda357ebb6db
+    skos:exactMatch soreabb:MarineEcosystem .
+gcmd:46a26fc7-95f0-409e-8bfa-eb623b3a3f8d
+    skos:exactMatch soreabb:Pasture .
+gcmd:3c8b236c-de02-491b-a506-91ecdc324a1c
+    skos:exactMatch soreabb:Rangelands .
+gcmd:f8d55ee4-1efb-4d83-b07f-1029ab0fa9e1
+    skos:exactMatch soreabb:Savanna .
+gcmd:d58dab07-f57e-47a9-8dcf-02a3e17f3533
+    skos:exactMatch soreabb:Savanna .
+gcmd:e36c5faa-c772-4bb0-aeca-b361e160ce9d
+    skos:exactMatch soreabb:SeaGrass .
+gcmd:9361962c-cfc7-4428-8843-b3502718c382
+    skos:exactMatch soreabb:TerrestrialEcosystem .
+gcmd:dacbf270-1734-4503-bab8-a32cdaff3012
+    skos:exactMatch soreaa:Mesopause .
+gcmd:82191e97-53ba-413d-9a08-acd8b848e0b0
+    skos:exactMatch soreaa:Stratopause .
+gcmd:c3447c90-7490-4f04-89c1-c5274ba8f8f6
+    skos:exactMatch soreaa:Tropopause .
+gcmd:1ef327e1-6139-49ff-87c3-f959ea75a511
+    skos:exactMatch soreaas:Corona .
+gcmd:c47f6052-634e-40ef-a5ac-13f69f6f4c2a
+    skos:exactMatch sorea:Atmosphere .
+gcmd:fa0a36c3-2503-4662-98cd-7f3e74ce9f80
+    skos:exactMatch sorea:Cryosphere .
+gcmd:91697b7d-8f2b-4954-850e-61d5f61c867d
+    skos:exactMatch sorea:Ocean .
+
+
+
+

--- a/alignments/sweet-gcmd-mapping.ttl
+++ b/alignments/sweet-gcmd-mapping.ttl
@@ -317,8 +317,6 @@ gcmd:cae5bafd-10a7-4bcf-af1a-3e187ee5e955
     skos:exactMatch sorealc:Shoal .
 gcmd:94b575b8-eac4-433d-aa74-d781b650f452
     skos:exactMatch sorealc:Shoal .
-gcmd:1d3b4eb7-9931-44bf-8457-26847051b7a8
-    skos:exactMatch sorealc:Shoreline .
 gcmd:57e6b119-567b-44d0-9d93-278ed5c21c47
     skos:exactMatch sorealc:Shoreline .
 gcmd:4e5cf935-cf17-4947-bd1f-6816a855953a
@@ -469,8 +467,6 @@ gcmd:5d7ea074-225b-4221-b122-e6a085cdce24
     skos:exactMatch soreac:PackIce .
 gcmd:ea85ea0b-1b7d-464a-9f8c-1f80383ffc51
     skos:exactMatch soreac:PackIce .
-gcmd:a4aea007-d297-4051-8b41-5cdde00b4d1e
-    skos:exactMatch soreac:SeaIce .
 gcmd:860e2af9-ce29-4f3f-b027-ae3747eb3e01
     skos:exactMatch soreac:SeaIce .
 gcmd:d73e969a-4b66-4713-8d63-fa3cbb1e25e3


### PR DESCRIPTION
partially addresses #159 
Per the last discussion at the most recent [semtech meeting](https://docs.google.com/document/d/1ilA1dYRSfm7OGJODCRy-dbDYzbfw4C_0Ap8tppYjW2Q/edit#heading=h.lduum3vh3i88), massive PRs of this nature should be broken up by group (realm, material, etc.)  As such I've created a draft mapping of GCMD science keywords to SWEET realms (all realm* files).   

There are 212 candidates, all of which are `skos:exactMatch`.  As the ttl file is sparse, please also see the results [spreadsheet](https://docs.google.com/spreadsheets/d/19rfWGGW0gfBcLjEqRf8c-TTcjCPloRUo6iWyiHE6cAg/edit?usp=sharing).

I used the following method:
Create key-value pair for each SWEET IRI and `rdfs:label` via SPARQL; Create key-value pair for each GCMD IRI and `skos:prefLabel` via SPARQL.
Then:

    for each k1,v1 pair in SWEET
      for each k2,v2 pair in GCMD
        if v1 (sequenceMatch) v2 >= 0.90:
          return k1, v1, match% k2, v2, GCMD_def

I did it this way out of sheer curiosity and the results were not as horrid as I would have thought.  I **manually** went through and removed the obvious false positives due to syntax --- adsorption != absorption for example (but still meets the 90% similarity threshold).  I also removed false positives due to the GCMD definition.   A simple example being [SWEET:rift valley](http://sweetontology.net/realmLandTectonic/RiftValley) which has (IIRC) three matches to GCMD, two of which are fine and you'll find them in the mapping file, but [one of which](https://gcmd.earthdata.nasa.gov/kms/concept/f32afbca-dac6-41b1-a198-791c1fb57951) has a definition including text about mid-ocean ridge.  On the face of it, it's fine, but as the SWEET term is situated in `realmLandTectonic` the candidate mapping was removed.

There are a host of other issues which can be addressed in due course --- assuming at least some of you agree the results aren't garbage. :)

I tagged a bunch of you in hopes at least 3 would be able to have a look.  It opens fine for me in Protege.  I did not test TopBraid.