### PR TITLE
added skos prefix and fixed comment spacing issue (protege)

### DIFF
--- a/src/matrMineral.ttl
+++ b/src/matrMineral.ttl
@@ -8,15 +8,14 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix soma: <http://sweetontology.net/matr/> .
 @prefix sostp: <http://sweetontology.net/statePhysical/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @base <http://sweetontology.net/matrMineral> .
 
 <http://sweetontology.net/matrMineral> rdf:type owl:Ontology ;
                                         owl:imports <http://sweetontology.net/matr> ,
                                                     <http://sweetontology.net/statePhysical> ;
                                         rdfs:label "SWEET Ontology Material Mineral" ;
-                                        rdfs:comment "List of names compiled manually primarily from the index pages of 'Introduction to Mineralogy' by Nesse (2000) (see https://www.worldcat.org/title/introduction-to-mineralogy/oclc/39961846) with some supporting information via mindat.org.  
-                                        
-                                        All newly added minerals are designated by the triple --- dcterms:contributor https://orcid.org/0000-0002-0337-8610"@en ;
+                                        rdfs:comment "List of names compiled manually primarily from the index pages of 'Introduction to Mineralogy' by Nesse (2000) (see https://www.worldcat.org/title/introduction-to-mineralogy/oclc/39961846) with supporting information via mindat.org. All newly added minerals are designated by the triple --- dcterms:contributor https://orcid.org/0000-0002-0337-8610"@en ;
                                         dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
                                         owl:versionInfo "3.5.0" .
 


### PR DESCRIPTION
minor issue; skos prefix missing and an odd spacing issue is causing protege to throw errors.  I think this sorts it.