### PR TITLE
Correct reprSciUnits.ttl

### DIFF
--- a/src/reprSciUnits.ttl
+++ b/src/reprSciUnits.ttl
@@ -388,7 +388,7 @@ sorepsu:degreeC rdf:type owl:NamedIndividual ,
                          sorepsu:UnitDerivedByShifting ;
                 sorelsc:hasBaseUnit sorepsu:kelvin ;
                 sorelm:hasShiftingNumber "-273.0"^^xsd:decimal ;
-                sorelsc:hasSymbol "C" ;
+                sorelsc:hasSymbol "°C" ;
                 rdfs:label "degree c"@en ;
                 skos:notation "Cel"^^qudt:UCUMcs .
 


### PR DESCRIPTION
Corrects discrepancy between degree C symbol created by improper merge sequence.

Changed
sorelsc:hasSymbol "C"
to
sorelsc:hasSymbol "°C"